### PR TITLE
storage:converters: including secondary allele alternates.

### DIFF
--- a/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/DBObjectToVariantSourceEntryConverter.java
+++ b/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/DBObjectToVariantSourceEntryConverter.java
@@ -147,7 +147,7 @@ public class DBObjectToVariantSourceEntryConverter implements ComplexTypeConvert
         BasicDBObject mongoFile = new BasicDBObject(FILEID_FIELD, object.getFileId()).append(STUDYID_FIELD, object.getStudyId());
 
         // Alternate alleles
-        if (object.getSecondaryAlternates().length > 1) {
+        if (object.getSecondaryAlternates().length > 0) {   // assuming secondaryAlternates doesn't contain the primary alternate
             mongoFile.append(ALTERNATES_FIELD, object.getSecondaryAlternates());
         }
         


### PR DESCRIPTION
The previous code assumed that the first element in secondaryAlternates was the primary alternate, thus, the code skipped `alts` if there were just one secondary alternate.