### PR TITLE
storage: logger fixes in SimpleThreadRunner and VepVariantAnnotator

### DIFF
--- a/opencga-lib/src/main/java/org/opencb/opencga/lib/common/ExceptionUtils.java
+++ b/opencga-lib/src/main/java/org/opencb/opencga/lib/common/ExceptionUtils.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.lib.common;
+
+/**
+ * Created by jmmut on 2015-07-02.
+ *
+ * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
+ */
+public class ExceptionUtils {
+    public static String getExceptionString(Exception e) {
+        StringBuilder stack = new StringBuilder(e.toString()).append("\n");
+        for (StackTraceElement stackTraceElement : e.getStackTrace()) {
+            stack.append("    ").append(stackTraceElement).append("\n");
+        }
+        return stack.toString();
+    }
+}

--- a/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunner.java
+++ b/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunner.java
@@ -3,6 +3,7 @@ package org.opencb.opencga.storage.core.runner;
 import org.opencb.commons.io.DataReader;
 import org.opencb.commons.io.DataWriter;
 import org.opencb.commons.run.Task;
+import org.opencb.opencga.lib.common.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,7 @@ public class SimpleThreadRunner {
         try {
             executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
         } catch (InterruptedException e) {
-            logger.error(getExceptionString(e));
+            logger.error(ExceptionUtils.getExceptionString(e));
         }
 
         for (Task task : tasks) {
@@ -97,14 +98,6 @@ public class SimpleThreadRunner {
 
     }
 
-    private String getExceptionString(Exception e) {
-        StringBuilder stack = new StringBuilder(e.toString()).append("\n");
-        for (StackTraceElement stackTraceElement : e.getStackTrace()) {
-            stack.append("    ").append(stackTraceElement).append("\n");
-        }
-        return stack.toString();
-    }
-    
     class ReaderRunnable implements Runnable {
 
         final DataReader dataReader;
@@ -126,7 +119,7 @@ public class SimpleThreadRunner {
                     readBlockingQueue.put(batch);
                     logger.trace("reader: postPut, readqueue.size: " + readBlockingQueue.size());
                 } catch (InterruptedException e) {
-                    logger.error(getExceptionString(e));
+                    logger.error(ExceptionUtils.getExceptionString(e));
                 }
 //                System.out.println("reader: preRead");
                 batch = dataReader.read(batchSize);
@@ -136,7 +129,7 @@ public class SimpleThreadRunner {
                 logger.debug("reader: putting POISON_PILL");
                 readBlockingQueue.put(POISON_PILL);
             } catch (InterruptedException e) {
-                logger.error(getExceptionString(e));
+                logger.error(ExceptionUtils.getExceptionString(e));
             }
         }
     }
@@ -161,7 +154,7 @@ public class SimpleThreadRunner {
             try {
                 batch = getBatch();
             } catch (InterruptedException e) {
-                logger.error(getExceptionString(e));
+                logger.error(ExceptionUtils.getExceptionString(e));
             }
             while (!batch.isEmpty()) {
                 try {
@@ -179,9 +172,9 @@ public class SimpleThreadRunner {
                     timeBlockedAtSendWrite += s - System.nanoTime();
                     batch = getBatch();
                 } catch (InterruptedException | IOException e) {
-                    logger.error(getExceptionString(e));
+                    logger.error(ExceptionUtils.getExceptionString(e));
                 } catch (Exception e) {
-                    logger.error("UNEXPECTED ENDING of a task thread due to an error:\n" + getExceptionString(e));
+                    logger.error("UNEXPECTED ENDING of a task thread due to an error:\n" + ExceptionUtils.getExceptionString(e));
                     return;
                 }
             }
@@ -196,7 +189,7 @@ public class SimpleThreadRunner {
                     try {
                         writeBlockingQueue.put(POISON_PILL);
                     } catch (InterruptedException e) {
-                        logger.error(getExceptionString(e));
+                        logger.error(ExceptionUtils.getExceptionString(e));
                     }
                 }
             }
@@ -232,7 +225,7 @@ public class SimpleThreadRunner {
             try {
                 batch = getBatch();
             } catch (InterruptedException e) {
-                logger.error(getExceptionString(e));
+                logger.error(ExceptionUtils.getExceptionString(e));
             }
             long s, timeWriting = 0;
 //            while (!batch.isEmpty()) {
@@ -245,7 +238,7 @@ public class SimpleThreadRunner {
                     timeWriting += s - System.nanoTime();
                     batch = getBatch();
                 } catch (InterruptedException e) {
-                    logger.error(getExceptionString(e));
+                    logger.error(ExceptionUtils.getExceptionString(e));
                 }
             }
             logger.debug("write: timeWriting = " + timeWriting / -1000000000.0 + "s");

--- a/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunner.java
+++ b/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunner.java
@@ -96,13 +96,13 @@ public class SimpleThreadRunner {
         }
 
     }
-    
+
     private String getExceptionString(Exception e) {
-        String stack = "";
+        StringBuilder stack = new StringBuilder(e.toString()).append("\n");
         for (StackTraceElement stackTraceElement : e.getStackTrace()) {
-            stack += "    " + stackTraceElement + "\n";
+            stack.append("    ").append(stackTraceElement).append("\n");
         }
-        return e.toString() + "\n" + stack;
+        return stack.toString();
     }
     
     class ReaderRunnable implements Runnable {

--- a/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunner.java
+++ b/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunner.java
@@ -78,7 +78,7 @@ public class SimpleThreadRunner {
         try {
             executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            logger.error(getExceptionString(e));
         }
 
         for (Task task : tasks) {
@@ -96,6 +96,15 @@ public class SimpleThreadRunner {
         }
 
     }
+    
+    private String getExceptionString(Exception e) {
+        String stack = "";
+        for (StackTraceElement stackTraceElement : e.getStackTrace()) {
+            stack += "    " + stackTraceElement + "\n";
+        }
+        return e.toString() + "\n" + stack;
+    }
+    
     class ReaderRunnable implements Runnable {
 
         final DataReader dataReader;
@@ -113,21 +122,21 @@ public class SimpleThreadRunner {
 
             while (batch != null && !batch.isEmpty()) {
                 try {
-//                    System.out.println("reader: prePut readBlockingQueue " + readBlockingQueue.size());
+                    logger.trace("reader: prePut readBlockingQueue.size: " + readBlockingQueue.size());
                     readBlockingQueue.put(batch);
-//                    System.out.println("reader: postPut");
+                    logger.trace("reader: postPut, readqueue.size: " + readBlockingQueue.size());
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    logger.error(getExceptionString(e));
                 }
 //                System.out.println("reader: preRead");
                 batch = dataReader.read(batchSize);
 //                System.out.println("reader: batch.size = " + batch.size());
             }
             try {
-                logger.debug("reader: POISON_PILL");
+                logger.debug("reader: putting POISON_PILL");
                 readBlockingQueue.put(POISON_PILL);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                logger.error(getExceptionString(e));
             }
         }
     }
@@ -152,26 +161,28 @@ public class SimpleThreadRunner {
             try {
                 batch = getBatch();
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                logger.error(getExceptionString(e));
             }
             while (!batch.isEmpty()) {
                 try {
                     long s;
-//                        System.out.println("task: apply");
                     s = System.nanoTime();
                     for (Task task : tasks) {
                         task.apply(batch);
                     }
                     timeTaskApply += s - System.nanoTime();
-//                    System.out.println("task: apply done " + writeBlockingQueue.size());
+//                    logger.trace("task: apply done, pre put, writeBlockingQueue.size: " + writeBlockingQueue.size());
 
                     s = System.nanoTime();
                     writeBlockingQueue.put(batch);
-//                    System.out.println("task: apply done");
+                    logger.trace("task: apply done (post put) writeQueue.size: " + writeBlockingQueue.size());
                     timeBlockedAtSendWrite += s - System.nanoTime();
                     batch = getBatch();
                 } catch (InterruptedException | IOException e) {
-                    e.printStackTrace();
+                    logger.error(getExceptionString(e));
+                } catch (Exception e) {
+                    logger.error("UNEXPECTED ENDING of a task thread due to an error:\n" + getExceptionString(e));
+                    return;
                 }
             }
             synchronized (numTasks) {
@@ -181,23 +192,25 @@ public class SimpleThreadRunner {
                 if (numTasks == finishedTasks) {
                     logger.debug("task; timeBlockedAtSendWrite = " + timeBlockedAtSendWrite / -1000000000.0 + "s");
                     logger.debug("task; timeTaskApply = " + timeTaskApply / -1000000000.0 + "s");
+                    logger.trace("task: putting POISON PILL");
                     try {
                         writeBlockingQueue.put(POISON_PILL);
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
+                        logger.error(getExceptionString(e));
                     }
                 }
             }
 
+            logger.trace("task: leaving run(). sizes: read: " + readBlockingQueue.size() + ", write: " + writeBlockingQueue.size());
 
         }
         private int finishedTasks = 0;
         private List<String> getBatch() throws InterruptedException {
             List<String> batch;
             batch = readBlockingQueue.take();
-//                System.out.println("task: readBlockingQueue = " + readBlockingQueue.size() + " batch.size : " + batch.size() + " : " + batchSize);
+            logger.trace("task: taken batch, readBlockingQueue.size = " + readBlockingQueue.size() + " batch.size : " + batch.size() + " : " + batchSize);
             if (batch == POISON_PILL) {
-                logger.debug("task: POISON_PILL");
+                logger.debug("task: received POISON_PILL");
                 readBlockingQueue.put(POISON_PILL);
             }
             return batch;
@@ -219,20 +232,20 @@ public class SimpleThreadRunner {
             try {
                 batch = getBatch();
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                logger.error(getExceptionString(e));
             }
             long s, timeWriting = 0;
 //            while (!batch.isEmpty()) {
             while (batch != POISON_PILL) {
                 try {
                     s = System.nanoTime();
-//                    System.out.println("writer: write");
+                    logger.trace("writer: writing...");
                     dataWriter.write(batch);
-//                    System.out.println("writer: wrote");
+                    logger.trace("writer: wrote");
                     timeWriting += s - System.nanoTime();
                     batch = getBatch();
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    logger.error(getExceptionString(e));
                 }
             }
             logger.debug("write: timeWriting = " + timeWriting / -1000000000.0 + "s");
@@ -241,10 +254,11 @@ public class SimpleThreadRunner {
 
         private List<String> getBatch() throws InterruptedException {
             List<String> batch;
-//                System.out.println("writer: writeBlockingQueue = " + writeBlockingQueue.size());
+                logger.trace("writer: about to block, writeBlockingQueue.size() = " + writeBlockingQueue.size());
 
             long s = System.nanoTime();
             batch = writeBlockingQueue.take();
+            logger.trace("writer: received batch, writing...");
             timeBlockedWatingDataToWrite += s - System.nanoTime();
             if (batch == POISON_PILL) {
                 logger.debug("writer: POISON_PILL");

--- a/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/variant/annotation/VepVariantAnnotator.java
+++ b/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/variant/annotation/VepVariantAnnotator.java
@@ -29,7 +29,7 @@ public class VepVariantAnnotator implements VariantAnnotator {
     private final JsonFactory factory;
     private ObjectMapper jsonObjectMapper;
 
-    protected static Logger logger = LoggerFactory.getLogger(CellBaseVariantAnnotator.class);
+    protected static Logger logger = LoggerFactory.getLogger(VepVariantAnnotator.class);
 
     public VepVariantAnnotator() {
         this.factory = new JsonFactory();


### PR DESCRIPTION
VepVariantAnnotator doesn't log as CellbaseAnnotator anymore, and SimpleThreadRunner now logs exceptions properly: before, it was hiding if the child threads running the tasks died because of unhandled exceptions.