### PR TITLE
FileWSServer index, check if bioformat is VARIANT before set hardcode…

### DIFF
--- a/opencga-analysis/src/main/java/org/opencb/opencga/analysis/storage/AnalysisFileIndexer.java
+++ b/opencga-analysis/src/main/java/org/opencb/opencga/analysis/storage/AnalysisFileIndexer.java
@@ -289,7 +289,7 @@ public class AnalysisFileIndexer {
                     .append(" --file-id ").append(originalFile.getId())
                     .append(" --database ").append(dataStore.getDbName())
                     .append(" --input ").append(catalogManager.getFileUri(inputFile))
-                    .append(" --calculate-coverage ").append(chunkSize)
+                    .append(" --calculate-coverage ")
                     .append(" --mean-coverage ").append(chunkSize)
                     .append(" --outdir ").append(outDirUri)
 //                    .append(" --credentials ")

--- a/opencga-server/src/main/java/org/opencb/opencga/server/FileWSServer.java
+++ b/opencga-server/src/main/java/org/opencb/opencga/server/FileWSServer.java
@@ -614,7 +614,10 @@ public class FileWSServer extends OpenCGAWSServer {
                 outDirId = catalogManager.getFileParent(fileId, null, sessionId).first().getId();
             }
             if (!queryOptions.containsKey(AnalysisFileIndexer.PARAMETERS)) {
-                queryOptions.put(AnalysisFileIndexer.PARAMETERS, Arrays.asList("--include-genotypes", "--calculate-stats", "--include-stats"));
+                File a = catalogManager.getFile(fileId, sessionId).getResult().get(0);
+                if(a.getBioformat() == File.Bioformat.VARIANT){
+                    queryOptions.put(AnalysisFileIndexer.PARAMETERS, Arrays.asList("--include-genotypes", "--calculate-stats", "--include-stats"));
+                }
             }
             queryResult = analysisFileIndexer.index(fileId, outDirId, sessionId, queryOptions);
 


### PR DESCRIPTION
FileWSServer: index, check if bioformat is VARIANT before set hardcoded parameters;
AnalysisFileIndexer: removed .append(chunkSize) from --calculate-coverage, this option does not expect any parameter.