### PR TITLE
storage: improved stats performance. (skipping sample names query) fixes #137

### DIFF
--- a/opencga-analysis/src/main/java/org/opencb/opencga/analysis/storage/variant/CatalogVariantDBAdaptor.java
+++ b/opencga-analysis/src/main/java/org/opencb/opencga/analysis/storage/variant/CatalogVariantDBAdaptor.java
@@ -54,6 +54,11 @@ public class CatalogVariantDBAdaptor implements VariantDBAdaptor {
     }
 
     @Override
+    public void setConstantSamples(String sourceEntry) {
+        
+    }
+
+    @Override
     public QueryResult<Variant> getAllVariants(QueryOptions options) {
 
         try {

--- a/opencga-analysis/src/main/java/org/opencb/opencga/analysis/storage/variant/CatalogVariantDBAdaptor.java
+++ b/opencga-analysis/src/main/java/org/opencb/opencga/analysis/storage/variant/CatalogVariantDBAdaptor.java
@@ -55,7 +55,7 @@ public class CatalogVariantDBAdaptor implements VariantDBAdaptor {
 
     @Override
     public void setConstantSamples(String sourceEntry) {
-        
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/opencga-storage/opencga-storage-app/src/main/java/org/opencb/opencga/storage/app/cli/OpenCGAStorageMain.java
+++ b/opencga-storage/opencga-storage-app/src/main/java/org/opencb/opencga/storage/app/cli/OpenCGAStorageMain.java
@@ -857,6 +857,7 @@ public class OpenCGAStorageMain {
             variantStorageManager.addConfigUri(new URI(null, c.credentials, null));
         }
         VariantDBAdaptor dbAdaptor = variantStorageManager.getDBAdaptor(c.dbName, queryOptions);
+        dbAdaptor.setConstantSamples(variantSource.getFileId());    // TODO jmmut: change to studyId when we remove fileId
 
         /**
          * Create and load stats

--- a/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/variant/adaptors/VariantDBAdaptor.java
+++ b/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/variant/adaptors/VariantDBAdaptor.java
@@ -103,6 +103,12 @@ public interface VariantDBAdaptor extends Iterable<Variant> {
     public void setDataWriter(DataWriter dataWriter);
 
     /**
+     * This method can be used if the samples are going to be the same, so optimizations can be done, e.g. skipping the 
+     * samples name retrieval for each variant.
+     */
+    public void setConstantSamples(String sourceEntry);
+
+    /**
      * Given a genomic region, it retrieves a set of variants and, optionally, all the information
      * about their samples, effects and statistics. These optional arguments are specified in the "options" dictionary,
      * with the keys (values must be set to true): "samples", "effects" and "stats", respectively.

--- a/opencga-storage/opencga-storage-hbase/src/main/java/org/opencb/opencga/storage/hbase/variant/VariantHbaseDBAdaptor.java
+++ b/opencga-storage/opencga-storage-hbase/src/main/java/org/opencb/opencga/storage/hbase/variant/VariantHbaseDBAdaptor.java
@@ -62,6 +62,10 @@ public class VariantHbaseDBAdaptor implements VariantDBAdaptor {
         db = mongoClient.getDB(credentials.getMongoDbName());
     }
 
+    @Override
+    public void setConstantSamples(String sourceEntry) {
+        
+    }
 
     @Override
     public QueryResult<Variant> getAllVariantsByRegionAndStudy(Region region, String sourceId, QueryOptions options) {

--- a/opencga-storage/opencga-storage-hbase/src/main/java/org/opencb/opencga/storage/hbase/variant/VariantHbaseDBAdaptor.java
+++ b/opencga-storage/opencga-storage-hbase/src/main/java/org/opencb/opencga/storage/hbase/variant/VariantHbaseDBAdaptor.java
@@ -64,7 +64,7 @@ public class VariantHbaseDBAdaptor implements VariantDBAdaptor {
 
     @Override
     public void setConstantSamples(String sourceEntry) {
-        
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/VariantMongoDBAdaptor.java
+++ b/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/VariantMongoDBAdaptor.java
@@ -34,8 +34,8 @@ public class VariantMongoDBAdaptor implements VariantDBAdaptor {
 
     private final MongoDataStoreManager mongoManager;
     private final MongoDataStore db;
-    private final DBObjectToVariantConverter variantConverter;
-    private final DBObjectToVariantSourceEntryConverter variantSourceEntryConverter;
+    private DBObjectToVariantConverter variantConverter;
+    private DBObjectToVariantSourceEntryConverter variantSourceEntryConverter;
     private final String collectionName;
     private final VariantSourceMongoDBAdaptor variantSourceMongoDBAdaptor;
 
@@ -65,6 +65,24 @@ public class VariantMongoDBAdaptor implements VariantDBAdaptor {
     @Override
     public void setDataWriter(DataWriter dataWriter) {
         this.dataWriter = dataWriter;
+    }
+
+    @Override
+    public void setConstantSamples(String sourceEntry) {
+        List<String> samples = null;
+        QueryResult samplesBySource = variantSourceMongoDBAdaptor.getSamplesBySource(sourceEntry, null);    // TODO jmmut: check when we remove fileId
+        if(samplesBySource.getResult().isEmpty()) {
+            logger.error("setConstantSamples(): couldn't find samples in source {} " + sourceEntry);
+        } else {
+            samples = (List<String>) samplesBySource.getResult().get(0);
+        }
+        
+        variantSourceEntryConverter = new DBObjectToVariantSourceEntryConverter(
+                true,
+                new DBObjectToSamplesConverter(samples)
+        );
+        
+        variantConverter = new DBObjectToVariantConverter(variantSourceEntryConverter, new DBObjectToVariantStatsConverter());
     }
 
     @Override
@@ -446,8 +464,8 @@ public class VariantMongoDBAdaptor implements VariantDBAdaptor {
             Map<String, VariantStats> cohortStats = wrapper.getCohortStats();
             Iterator<VariantStats> iterator = cohortStats.values().iterator();
             VariantStats variantStats = iterator.hasNext()? iterator.next() : null;
-            List<DBObject> cohorts = statsConverter.convertCohortsToStorageType(cohortStats, variantSource.getStudyId(), variantSource.getFileId());   // TODO remove when we remove fileId
-//            List cohorts = statsConverter.convertCohortsToStorageType(cohortStats, variantSource.getStudyId());   // TODO use when we remove fileId
+            List<DBObject> cohorts = statsConverter.convertCohortsToStorageType(cohortStats, variantSource.getStudyId(), variantSource.getFileId());   // TODO jmmut: remove when we remove fileId
+//            List cohorts = statsConverter.convertCohortsToStorageType(cohortStats, variantSource.getStudyId());   // TODO jmmut: use when we remove fileId
             
             if (!cohorts.isEmpty()) {
                 String id = variantConverter.buildStorageId(wrapper.getChromosome(), wrapper.getPosition(),

--- a/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/VariantSourceMongoDBAdaptor.java
+++ b/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/VariantSourceMongoDBAdaptor.java
@@ -79,7 +79,7 @@ public class VariantSourceMongoDBAdaptor implements VariantSourceDBAdaptor {
     }
 
     @Override
-    public QueryResult getSamplesBySource(String fileId, QueryOptions options) {
+    public QueryResult getSamplesBySource(String fileId, QueryOptions options) {    // TODO jmmut: deprecate when we remove fileId, and change for getSamplesBySource(String studyId, QueryOptions options)
         if (samplesInSources.size() != (long) countSources().getResult().get(0)) {
             synchronized (StudyMongoDBAdaptor.class) {
                 if (samplesInSources.size() != (long) countSources().getResult().get(0)) {


### PR DESCRIPTION
fixes #137 

cherry picked from c8e66f7e17805c1eb1962ca1d7b793c061e8a61e

---
Previously, each time a variant was fetched from the DBAdaptor
(DBIterator actually), the inner DBObjectToSamplesConverter made
another query to Mongo to find out the sample names.

In main.statsVariants(), this is a waste because every variant will
share sourceEntry, so the names list will allways be the same. For that,
the adaptor now can be told to fetch the sample names just once at the
beginning.

Conflicts cherry-picking (took ours):
* opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/runner/StringDataWriter.java
* opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/variant/io/VariantDBReader.java
* opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/variant/stats/VariantStatisticsManager.java