### PR TITLE
New option 'sort' 

### DIFF
--- a/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/variant/adaptors/VariantDBAdaptor.java
+++ b/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/variant/adaptors/VariantDBAdaptor.java
@@ -5,9 +5,7 @@ import java.util.*;
 import org.opencb.biodata.models.feature.Region;
 import org.opencb.biodata.models.variant.Variant;
 import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
-import org.opencb.biodata.models.variant.stats.VariantStats;
 import org.opencb.commons.io.DataWriter;
-import org.opencb.datastore.core.ObjectMap;
 import org.opencb.datastore.core.QueryOptions;
 import org.opencb.datastore.core.QueryResult;
 import org.opencb.opencga.storage.core.variant.stats.VariantStatsWrapper;
@@ -43,6 +41,7 @@ public interface VariantDBAdaptor extends Iterable<Variant> {
     public static final String PROTEIN_SUBSTITUTION = "protein_substitution";
     public static final String CONSERVED_REGION = "conserved_region";
     public static final String MERGE = "merge";
+    public static final String SORT = "sort";
 
     static public class QueryParams {
         public static final Set<String> acceptedValues;

--- a/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/VariantMongoDBAdaptor.java
+++ b/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/VariantMongoDBAdaptor.java
@@ -144,7 +144,7 @@ public class VariantMongoDBAdaptor implements VariantDBAdaptor {
         if (options == null) {
             options = new QueryOptions();
         }
-        options.add("sort", new BasicDBObject("chr", 1).append("start", 1));
+        
         QueryResult<Variant> queryResult = coll.find(qb.get(), projection, variantConverter, options);
         queryResult.setId(region.toString());
         return queryResult;
@@ -156,6 +156,12 @@ public class VariantMongoDBAdaptor implements VariantDBAdaptor {
         if (options == null) {
             options = new QueryOptions();
         }
+        
+        // If the users asks to sort the results, do it by chromosome and start
+        if (options.getBoolean(SORT, false)) {
+            options.put(SORT, new BasicDBObject("chr", 1).append("start", 1));
+        }
+        
         // If the user asks to merge the results, run only one query,
         // otherwise delegate in the method to query regions one by one
         if (options.getBoolean(MERGE, false)) {


### PR DESCRIPTION
A new option "sort" allows users to choose if they want to sort the results returned from a query by region(s). By default there is no sorting, for the sake of performance.