### PR TITLE
analysis: added filename to stats serialization.

### DIFF
--- a/opencga-analysis/src/main/java/org/opencb/opencga/analysis/storage/variant/VariantStorage.java
+++ b/opencga-analysis/src/main/java/org/opencb/opencga/analysis/storage/variant/VariantStorage.java
@@ -60,6 +60,7 @@ public class VariantStorage {
             }
             outputFileName.append(cohort.getName());
         }
+        outputFileName.insert(0, indexFile.getName() + ".");
 
         File outDir;
         if (outDirId == null || outDirId <= 0) {


### PR DESCRIPTION
This is done to be able to recognize stats of the same cohorts but from
different files.