### PR TITLE
storage: added option to overwrite stats

### DIFF
--- a/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/variant/stats/VariantStatisticsManager.java
+++ b/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/variant/stats/VariantStatisticsManager.java
@@ -202,6 +202,7 @@ public class VariantStatisticsManager {
         long start = System.currentTimeMillis();
 
         loadVariantStats(variantDBAdaptor, variantStatsUri, options);
+        logger.info("variant stats loaded, next is loading source stats");
         loadSourceStats(variantDBAdaptor, sourceStatsUri, options);
 
         logger.info("finishing stats loading, time: {}ms", System.currentTimeMillis() - start);

--- a/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/VariantMongoDBAdaptor.java
+++ b/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/VariantMongoDBAdaptor.java
@@ -509,7 +509,7 @@ public class VariantMongoDBAdaptor implements VariantDBAdaptor {
                         new BasicDBObject(DBObjectToVariantConverter.STATS_FIELD,
                                 new BasicDBObject("$each", cohorts)));
 
-                pushBuilder.find(find).update(push);
+                pushBuilder.find(find).updateOne(push);
             }
         }
 


### PR DESCRIPTION
giving "--overwrite-stats" in the storage CLI, the update will do before an
extra pull, removing the cohort stats with the same cid, sid and fid than the
cohort stats it is going to push.

if that option is not present, it will just push the cohort stats, leaving them
repeated if they were already present