### PR TITLE
storage: bugfix with SimpleThreadRunner child exceptions

### DIFF
--- a/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunner.java
+++ b/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunner.java
@@ -78,7 +78,7 @@ public class SimpleThreadRunner {
         executorService.shutdown();
         try {
             executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
-        } catch (InterruptedException e) {
+        } catch (Exception e) {
             logger.error(ExceptionUtils.getExceptionString(e));
         }
 
@@ -130,6 +130,8 @@ public class SimpleThreadRunner {
                 readBlockingQueue.put(POISON_PILL);
             } catch (InterruptedException e) {
                 logger.error(ExceptionUtils.getExceptionString(e));
+            } catch (Exception e) {
+                logger.error("UNEXPECTED ENDING of a reader thread due to an error:\n" + ExceptionUtils.getExceptionString(e));
             }
         }
     }
@@ -239,6 +241,8 @@ public class SimpleThreadRunner {
                     batch = getBatch();
                 } catch (InterruptedException e) {
                     logger.error(ExceptionUtils.getExceptionString(e));
+                } catch (Exception e) {
+                    logger.error("UNEXPECTED ENDING of a writer thread due to an error:\n" + ExceptionUtils.getExceptionString(e));
                 }
             }
             logger.debug("write: timeWriting = " + timeWriting / -1000000000.0 + "s");


### PR DESCRIPTION
The logs added help explaining some hangs and restores messages otherwise lost