### PR TITLE
More SimpleThreadRunner improvements

### DIFF
--- a/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/variant/VariantStorageManager.java
+++ b/opencga-storage/opencga-storage-core/src/main/java/org/opencb/opencga/storage/core/variant/VariantStorageManager.java
@@ -127,7 +127,7 @@ public abstract class VariantStorageManager implements StorageManager<VariantWri
      * @throws IOException
      */
     @Override
-    final public URI transform(URI inputUri, URI pedigreeUri, URI outputUri, ObjectMap params) throws IOException {
+    final public URI transform(URI inputUri, URI pedigreeUri, URI outputUri, ObjectMap params) throws IOException, StorageManagerException {
         // input: VcfReader
         // output: JsonWriter
 
@@ -240,7 +240,11 @@ public abstract class VariantStorageManager implements StorageManager<VariantWri
 
             logger.info("Multi thread transform...");
             start = System.currentTimeMillis();
-            runner.run();
+            try {
+                runner.run();
+            } catch (Exception e) {
+                throw new StorageManagerException("VariantStorageManager.transform failed, runner threw exception", e);
+            }
             end = System.currentTimeMillis();
         }
         logger.info("end - start = " + (end - start) / 1000.0 + "s");

--- a/opencga-storage/opencga-storage-core/src/test/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunnerTest.java
+++ b/opencga-storage/opencga-storage-core/src/test/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunnerTest.java
@@ -1,0 +1,330 @@
+package org.opencb.opencga.storage.core.runner;
+
+import org.junit.Test;
+import org.opencb.commons.io.DataReader;
+import org.opencb.commons.io.DataWriter;
+import org.opencb.commons.run.Task;
+import org.opencb.opencga.lib.common.ExceptionUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by jmmut on 2015-10-06.
+ *
+ * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
+ */
+public class SimpleThreadRunnerTest {
+
+    @Test(timeout = 5000)
+    public void correctTest() throws Exception {
+        final AtomicInteger processedElems = new AtomicInteger(0);
+        List<String> data = Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9");
+
+        //Reader
+        DataReader dataReader = new TestDataReader(data, processedElems, false);
+
+        // Task
+        Task task = new TestTask(processedElems, false);
+
+        //Writer
+        DataWriter dataWriter = new TestDataWriter(processedElems, false);
+
+        SimpleThreadRunner runner = new SimpleThreadRunner(
+                dataReader,
+                Collections.singletonList(task),
+                dataWriter,
+                3,
+                4,
+                1
+        );
+
+        runner.run();
+        System.out.println(processedElems.get());
+        assertEquals(data.size()*3, processedElems.get());
+
+
+
+
+
+
+
+        Callable callableTask = new Callable<Void> () {
+
+            @Override
+            public Void call ()throws Exception {
+                throw new Exception("exception from callable");
+//                return null;
+            }
+        };
+
+
+
+
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        Future future = executorService.submit(callableTask);
+//        try {
+//            future.get();
+//        } catch (ExecutionException ex) {
+//            ex.getCause().printStackTrace();
+//        }
+//        executorService.submit(callableTask);
+//        executorService.shutdown();
+        try {
+
+//            executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
+            future.get();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test(timeout = 5000)
+    public void interruptedReaderTest () throws Exception {
+        final AtomicInteger processedElems = new AtomicInteger(0);
+        List<String> data = Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9");
+
+        //Reader
+        DataReader dataReader = new TestDataReader(data, processedElems, true);
+
+        // Task
+        Task task = new TestTask(processedElems, false);
+
+        //Writer
+        DataWriter dataWriter = new TestDataWriter(processedElems, false);
+
+        SimpleThreadRunner runner = new SimpleThreadRunner(
+                dataReader,
+                Collections.singletonList(task),
+                dataWriter,
+                3,
+                4,
+                1
+        );
+
+        try {
+            runner.run();
+            fail();
+        } catch (Exception e) {
+            System.out.println("expected exception");
+        }
+    }
+
+    @Test(timeout = 5000)
+    public void interruptedTaskTest () throws Exception {
+        final AtomicInteger processedElems = new AtomicInteger(0);
+        List<String> data = Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9");
+
+        //Reader
+        DataReader dataReader = new TestDataReader(data, processedElems, false);
+
+        // Task
+        Task task = new TestTask(processedElems, true);
+
+        //Writer
+        DataWriter dataWriter = new TestDataWriter(processedElems, false);
+
+        SimpleThreadRunner runner = new SimpleThreadRunner(
+                dataReader,
+                Collections.singletonList(task),
+                dataWriter,
+                3,
+                4,
+                1
+        );
+
+        try {
+            runner.run();
+            fail();
+        } catch (Exception e) {
+            System.out.println("expected exception");
+        }
+    }
+
+    @Test(timeout = 5000)
+    public void interruptedWriterTest () throws Exception {
+        final AtomicInteger processedElems = new AtomicInteger(0);
+        List<String> data = Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9");
+
+        //Reader
+        DataReader dataReader = new TestDataReader(data, processedElems, true);
+
+        // Task
+        Task task = new TestTask(processedElems, false);
+
+        //Writer
+        DataWriter dataWriter = new TestDataWriter(processedElems, false);
+
+        SimpleThreadRunner runner = new SimpleThreadRunner(
+                dataReader,
+                Collections.singletonList(task),
+                dataWriter,
+                3,
+                4,
+                1
+        );
+
+        try {
+            runner.run();
+            fail();
+        } catch (Exception e) {
+            System.out.println("expected exception");
+        }
+    }
+
+    public class TestDataReader implements DataReader {
+        private List<String> data;
+        private int cursor = 0;
+        private final AtomicInteger processedElems;
+        private boolean interrupt;
+
+        public TestDataReader(List<String> data, AtomicInteger processedElems, boolean interrupt) {
+            this.data = data;
+            this.processedElems = processedElems;
+            this.interrupt = interrupt;
+        }
+
+        @Override
+        public boolean open() {
+            return false;
+        }
+
+        @Override
+        public boolean close() {
+            return false;
+        }
+
+        @Override
+        public boolean pre() {
+            return false;
+        }
+
+        @Override
+        public boolean post() {
+            return false;
+        }
+
+        @Override
+        public List read() {
+            return read(1);
+        }
+
+        /**
+         * return at most a list of `batchSize` elements. return null if there aren't any elements.
+         * @param batchSize
+         * @return
+         */
+        @Override
+        public List read(int batchSize) {
+            List<String> ret = new ArrayList<>();
+            for (int i = 0; i < batchSize && cursor < data.size(); i++, cursor++) {
+                ret.add(data.get(cursor));
+                System.out.println("read elem " + data.get(cursor));
+                processedElems.incrementAndGet();
+                if (cursor == 7 && interrupt) {
+                    throw new RuntimeException("Fake read interrupt");
+                }
+            }
+            if (ret.isEmpty()) {
+                System.out.println("read null");
+                ret = null;
+            }
+
+            return ret;
+        }
+    }
+
+    private class TestTask extends Task {
+        private final AtomicInteger processedElems;
+        private boolean interrupt;
+        private int processed = 0;
+
+        public TestTask(AtomicInteger processedElems, boolean interrupt) {
+            this.processedElems = processedElems;
+            this.interrupt = interrupt;
+        }
+
+        @Override
+        public boolean apply(List batch) throws IOException {
+            if (batch == null) {
+                System.out.println("apply null");
+                return false;
+            }
+            for (Object elem : batch) {
+                System.out.println("apply elem " + elem);
+                processedElems.incrementAndGet();
+                processed++;
+                if (processed == 7 && interrupt) {
+                    throw new RuntimeException("Fake task interrupt");
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public int compareTo(Object o) {
+            return 0;
+        }
+    }
+
+    private class TestDataWriter implements DataWriter {
+        private final AtomicInteger processedElems;
+        private boolean interrupt;
+        private int processed = 0;
+
+        public TestDataWriter(AtomicInteger processedElems, boolean interrupt) {
+            this.processedElems = processedElems;
+            this.interrupt = interrupt;
+        }
+
+        @Override
+        public boolean open() {
+            return false;
+        }
+
+        @Override
+        public boolean close() {
+            return false;
+        }
+
+        @Override
+        public boolean pre() {
+            return false;
+        }
+
+        @Override
+        public boolean post() {
+            return false;
+        }
+
+        @Override
+        public boolean write(Object elem) {
+            return write(1);
+        }
+
+        @Override
+        public boolean write(List batch) {
+            if (batch == null) {
+                System.out.println("write null");
+                return false;
+            }
+            for (Object elem : batch) {
+                System.out.println("write elem " + elem);
+                processedElems.incrementAndGet();
+                processed++;
+                if (processed == 7 && interrupt) {
+                    throw new RuntimeException("Fake writer interrupt");
+                }
+            }
+            return true;
+        }
+    }
+}
+

--- a/opencga-storage/opencga-storage-core/src/test/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunnerTest.java
+++ b/opencga-storage/opencga-storage-core/src/test/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunnerTest.java
@@ -86,6 +86,17 @@ public class SimpleThreadRunnerTest {
         }
     }
 
+//    @Test
+//    public void finallyTest () throws Exception {
+//        try {
+//            throw new InterruptedException("interrupted");
+//        } catch (Exception e) {
+//            throw new Exception(e);
+//        } finally {
+//            System.out.println("on finally");
+//        }
+//    }
+
     @Test(timeout = 5000)
     public void interruptedReaderTest () throws Exception {
         final AtomicInteger processedElems = new AtomicInteger(0);
@@ -154,13 +165,13 @@ public class SimpleThreadRunnerTest {
         List<String> data = Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9");
 
         //Reader
-        DataReader dataReader = new TestDataReader(data, processedElems, true);
+        DataReader dataReader = new TestDataReader(data, processedElems, false);
 
         // Task
         Task task = new TestTask(processedElems, false);
 
         //Writer
-        DataWriter dataWriter = new TestDataWriter(processedElems, false);
+        DataWriter dataWriter = new TestDataWriter(processedElems, true);
 
         SimpleThreadRunner runner = new SimpleThreadRunner(
                 dataReader,
@@ -225,6 +236,11 @@ public class SimpleThreadRunnerTest {
         public List read(int batchSize) {
             List<String> ret = new ArrayList<>();
             for (int i = 0; i < batchSize && cursor < data.size(); i++, cursor++) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
                 ret.add(data.get(cursor));
                 System.out.println("read elem " + data.get(cursor));
                 processedElems.incrementAndGet();
@@ -319,7 +335,7 @@ public class SimpleThreadRunnerTest {
                 System.out.println("write elem " + elem);
                 processedElems.incrementAndGet();
                 processed++;
-                if (processed == 7 && interrupt) {
+                if (processed == 1 && interrupt) {
                     throw new RuntimeException("Fake writer interrupt");
                 }
             }

--- a/opencga-storage/opencga-storage-core/src/test/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunnerTest.java
+++ b/opencga-storage/opencga-storage-core/src/test/java/org/opencb/opencga/storage/core/runner/SimpleThreadRunnerTest.java
@@ -49,41 +49,6 @@ public class SimpleThreadRunnerTest {
         runner.run();
         System.out.println(processedElems.get());
         assertEquals(data.size()*3, processedElems.get());
-
-
-
-
-
-
-
-        Callable callableTask = new Callable<Void> () {
-
-            @Override
-            public Void call ()throws Exception {
-                throw new Exception("exception from callable");
-//                return null;
-            }
-        };
-
-
-
-
-        ExecutorService executorService = Executors.newFixedThreadPool(1);
-        Future future = executorService.submit(callableTask);
-//        try {
-//            future.get();
-//        } catch (ExecutionException ex) {
-//            ex.getCause().printStackTrace();
-//        }
-//        executorService.submit(callableTask);
-//        executorService.shutdown();
-        try {
-
-//            executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
-            future.get();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
     }
 
 //    @Test

--- a/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/MongoDBVariantStorageManager.java
+++ b/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/MongoDBVariantStorageManager.java
@@ -118,7 +118,7 @@ public class MongoDBVariantStorageManager extends VariantStorageManager {
     }
 
     @Override
-    public URI load(URI inputUri, ObjectMap params) throws IOException {
+    public URI load(URI inputUri, ObjectMap params) throws IOException, StorageManagerException {
         // input: getDBSchemaReader
         // output: getDBWriter()
 
@@ -207,7 +207,11 @@ public class MongoDBVariantStorageManager extends VariantStorageManager {
                     batchSize,
                     loadThreads*2,
                     0);
-            threadRunner.run();
+            try {
+                threadRunner.run();
+            } catch (Exception e) {
+                throw new StorageManagerException("MongoDBVariantStorageManager.load failed: runner threw exception", e);
+            }
 
         }
 


### PR DESCRIPTION
Now there is a policy of fast abort.

When a reader, a task, or a writer throws an exception:
* it is logged
* the loops are stopped
* the resources are closed (logging possible nested exceptions)
* the runner throws the original cause of failure.

Previously, if there was an error like an unavailable DB, it hang, logging it indefinitely without exiting the program. 