### PR TITLE
SourceDBAdaptor: fixed bug about samples containing '.'

### DIFF
--- a/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/VariantSourceMongoDBAdaptor.java
+++ b/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/VariantSourceMongoDBAdaptor.java
@@ -183,7 +183,13 @@ public class VariantSourceMongoDBAdaptor implements VariantSourceDBAdaptor {
         for (DBObject dbo : result) {
             String key = dbo.get(DBObjectToVariantSourceConverter.FILEID_FIELD).toString();
             DBObject value = (DBObject) dbo.get(DBObjectToVariantSourceConverter.SAMPLES_FIELD);
-            samplesInSources.put(key, new ArrayList(value.toMap().keySet()));
+
+            // replace '£' by '.'
+            List<String> sampleNames = new ArrayList<>();
+            for (String mongoSampleName : value.keySet()) {
+                sampleNames.add(mongoSampleName.replace(DBObjectToVariantSourceConverter.CHARACTER_TO_REPLACE_DOTS, '.'));
+            }
+            samplesInSources.put(key, sampleNames);
         }
         
         return queryResult;


### PR DESCRIPTION
Although the `DBObjectToVariantSourceConverter` is the one that replaces `'.'` with `'£'`, the `VariantSourceMongoDBAdaptor` also queries `DBObjectToVariantSourceConverter.SAMPLES_FIELD`, so it has to do the replacement as well.