### PR TITLE
Replacing dots in VariantSourceEntry attributes map

### DIFF
--- a/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/DBObjectToVariantSourceEntryConverter.java
+++ b/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/DBObjectToVariantSourceEntryConverter.java
@@ -24,6 +24,7 @@ public class DBObjectToVariantSourceEntryConverter implements ComplexTypeConvert
     public final static String ATTRIBUTES_FIELD = "attrs";
     public final static String FORMAT_FIELD = "fm";
     public final static String SAMPLES_FIELD = "samp";
+    static final char CHARACTER_TO_REPLACE_DOTS = (char) 163; // <-- £
     
     private VariantStorageManager.IncludeSrc includeSrc;
 
@@ -75,7 +76,11 @@ public class DBObjectToVariantSourceEntryConverter implements ComplexTypeConvert
         
         // Attributes
         if (object.containsField(ATTRIBUTES_FIELD)) {
-            file.setAttributes(((DBObject) object.get(ATTRIBUTES_FIELD)).toMap());
+            BasicDBObject attributes = (BasicDBObject) object.get(ATTRIBUTES_FIELD);
+            for (Map.Entry<String, Object> o : attributes.entrySet()) {
+                file.addAttribute(o.getKey().replace(CHARACTER_TO_REPLACE_DOTS, '.'), o.getValue().toString());
+            }
+            
             // Unzip the "src" field, if available
             if (((DBObject) object.get(ATTRIBUTES_FIELD)).containsField("src")) {
                 byte[] o = (byte[]) ((DBObject) object.get(ATTRIBUTES_FIELD)).get("src");
@@ -143,9 +148,9 @@ public class DBObjectToVariantSourceEntryConverter implements ComplexTypeConvert
                 }
 
                 if (attrs == null) {
-                    attrs = new BasicDBObject(entry.getKey(), value);
+                    attrs = new BasicDBObject(entry.getKey().replace('.', CHARACTER_TO_REPLACE_DOTS), value);
                 } else {
-                    attrs.append(entry.getKey(), value);
+                    attrs.append(entry.getKey().replace('.', CHARACTER_TO_REPLACE_DOTS), value);
                 }
             }
 

--- a/opencga-storage/opencga-storage-mongodb/src/test/java/org/opencb/opencga/storage/mongodb/variant/DBObjectToVariantSourceEntryConverterTest.java
+++ b/opencga-storage/opencga-storage-mongodb/src/test/java/org/opencb/opencga/storage/mongodb/variant/DBObjectToVariantSourceEntryConverterTest.java
@@ -36,6 +36,7 @@ public class DBObjectToVariantSourceEntryConverterTest {
         file = new VariantSourceEntry("f1", "s1");
         file.addAttribute("QUAL", "0.01");
         file.addAttribute("AN", "2");
+        file.addAttribute("MAX.PROC", "2");
         file.setFormat("GT");
         
         Map<String, String> na001 = new HashMap<>();
@@ -52,7 +53,8 @@ public class DBObjectToVariantSourceEntryConverterTest {
         mongoFile = new BasicDBObject(DBObjectToVariantSourceEntryConverter.FILEID_FIELD, file.getFileId())
                 .append(DBObjectToVariantSourceEntryConverter.STUDYID_FIELD, file.getStudyId());
         mongoFile.append(DBObjectToVariantSourceEntryConverter.ATTRIBUTES_FIELD,
-                new BasicDBObject("QUAL", "0.01").append("AN", "2"));
+                new BasicDBObject("QUAL", "0.01").append("AN", "2")
+                        .append("MAX" + DBObjectToVariantSourceEntryConverter.CHARACTER_TO_REPLACE_DOTS + "PROC", "2"));
         mongoFile.append(DBObjectToVariantSourceEntryConverter.FORMAT_FIELD, file.getFormat());
         BasicDBObject genotypeCodes = new BasicDBObject();
         genotypeCodes.append("def", "0/0");


### PR DESCRIPTION
Replacing dots with the pound symbol when converting *VariantSourceEntry.attributes*. Also requires https://github.com/opencb/biodata/pull/85.