### PR TITLE
pyCGA - Login decorator now creates proper config files

### DIFF
--- a/opencga-client/src/main/python/pyCGA/Utils/decorators.py
+++ b/opencga-client/src/main/python/pyCGA/Utils/decorators.py
@@ -33,7 +33,7 @@ def catalog_login(func):
 
     def create_session_file(configuration, opencga_dir):
         fdw = open(os.path.join(opencga_dir, 'session_python.json'), 'w')
-        user = input("User: ")
+        user = raw_input("User: ")
         pwd = getpass.getpass()
         o = OpenCGAClient(configuration=configuration, user=user, pwd=pwd)
         session = {'userId': user, 'sessionId': o.session_id}
@@ -46,10 +46,16 @@ def catalog_login(func):
 
         fdw = open(os.path.join(opencga_dir, 'configuration.json'), 'w')
         if not configuration:
-            host = input("Please provide OpenCGA Host name: ")
-            configuration = {'version': 'v1', 'rest': {'hosts': [host]}}
-        json.dump(configuration, fdw)
+            host = raw_input("Please provide OpenCGA Host name: ")
+            conf_json = {'version': 'v1', 'rest': {'hosts': [host]}}
+            json.dump(conf_json, fdw)
+        if isinstance(configuration, dict):
+            conf_json = configuration
+        else:
+            conf_json = json.load(open(configuration, 'r'))
+        json.dump(conf_json, fdw)
+
         fdw.close()
-        return configuration
+        return conf_json
 
     return log_method

--- a/opencga-client/src/main/python/pyCGA/commons.py
+++ b/opencga-client/src/main/python/pyCGA/commons.py
@@ -15,7 +15,7 @@ _NUM_THREADS_DEFAULT = 4
 class OpenCGAResponse(list):
 
     def __init__(self, response):
-        self.action_id = response['id']
+        # self.action_id = response['id']
         self.time = response['time']
         self.dbTime = response['dbTime']
         self.numResults = response['numResults']


### PR DESCRIPTION
- Fixed a bug when if the configuration provided is a file, its path and not its content is stored in ".opencga" configuration folder.
- Fixed username input, quotes are not longer needed.
- Response id is no longer stored due to the lack of it in some OpenCGA responses.