### PR TITLE
pyCGA: dont retry on certain exceptions

### DIFF
--- a/opencga-client/src/main/python/pyCGA/opencgarestclients.py
+++ b/opencga-client/src/main/python/pyCGA/opencgarestclients.py
@@ -38,7 +38,7 @@ class _ParentRestClient(object):
             return str(query_ids)
 
     def _rest_retry(self, method, resource, query_id=None, subcategory=None,
-                    second_query_id=None, data=None, **options):
+                    second_query_id=None, data=None, dont_retry=None, **options):
         """Invokes the specified HTTP method, with retries if they are specified in the configuration
         :return: an instance of OpenCGAResponseList"""
 
@@ -69,7 +69,7 @@ class _ParentRestClient(object):
         response = retry(
             exec_retry, self._cfg.max_attempts, self._cfg.min_retry_secs, self._cfg.max_retry_secs,
             login_handler=self._client_login_handler if self.login_handler else None,
-            on_retry=notify_retry)
+            on_retry=notify_retry, dont_retry=dont_retry)
 
         if self.auto_refresh:
             self._refresh_token_client()

--- a/opencga-client/src/main/python/setup.py
+++ b/opencga-client/src/main/python/setup.py
@@ -2,12 +2,12 @@ from distutils.core import setup
 
 setup(
     name='pyCGA',
-    version='1.2.0',
+    version='1.2.1',
     packages=['pyCGA', 'pyCGA.Utils'],
     url='https://github.com/genomicsengland/opencga/tree/pycga-1.0/opencga-client/src/main/python',
     license='',
     author='antonior,dapregi,ernesto-ocampo',
-    author_email='antonio.rueda-martin@genomicsengland.co.uk,daniel.perez-gil@genomicsengland.co.uk,ernesto.ocampo@genomicsengland.co.uk',
+    author_email='antonio.rueda-martin@genomicsengland.co.uk,daniel.perez-gil@genomicsengland.co.uk,kenan.mcgrath@genomicsengland.co.uk',
     description='Version 1.0.10: Changes in the AvroSchema module',
     install_requires=[
         'pip >= 7.1.2',


### PR DESCRIPTION
Adds a parameter to the pyCGA client to not retry on certain error messages.