### PR TITLE
client: add pyyaml to python client requirements.txt

### DIFF
--- a/opencga-client/src/main/python/requirements.txt
+++ b/opencga-client/src/main/python/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.7
 avro==1.7.7
 pathlib>=1.0.1
 requests_toolbelt>=0.7.0
+pyyaml>=3.12


### PR DESCRIPTION
while testing out the python client  I noticed that pyyaml was not included in requirements.txt.