### PR TITLE
bug fixed: removed "project" parameter from the StudyManager query in…

### DIFF
--- a/opencga-server/src/main/java/org/opencb/opencga/server/rest/StudyWSServer.java
+++ b/opencga-server/src/main/java/org/opencb/opencga/server/rest/StudyWSServer.java
@@ -117,6 +117,7 @@ public class StudyWSServer extends OpenCGAWSServer {
                 projectStr = projectId;
                 query.remove(StudyDBAdaptor.QueryParams.PROJECT_ID.key());
             }
+            query.remove("project");
 
             queryOptions.put(QueryOptions.SKIP_COUNT, skipCount);
 

--- a/opencga-server/src/main/java/org/opencb/opencga/server/rest/analysis/ClinicalAnalysisWSService.java
+++ b/opencga-server/src/main/java/org/opencb/opencga/server/rest/analysis/ClinicalAnalysisWSService.java
@@ -38,7 +38,7 @@ import java.util.List;
 import static org.opencb.opencga.storage.core.variant.adaptors.VariantQueryParam.*;
 import static org.opencb.opencga.storage.core.clinical.ReportedVariantQueryParam.*;
 
-@Path("/{version}/analysis/clinical")
+@Path("/{apiVersion}/analysis/clinical")
 @Produces(MediaType.APPLICATION_JSON)
 @Api(value = "Analysis - Clinical Interpretation", position = 4, description = "Methods for working with Clinical Analysis")
 public class ClinicalAnalysisWSService extends AnalysisWSService {


### PR DESCRIPTION
… studies/search web service, which made it trivially uncallable except when using the deprecated "projectId" parameter instead (and unusable from swagger)