### PR TITLE
Add sslEnabled support to the MongoDBAdapterFactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ opencga-test/fitnesse/FitNesseRoot/RecentChanges.wiki
 # Python
 *.pyc
 venv
+
+# Java annotation processor (APT)
+.factorypath

--- a/opencga-catalog/src/main/java/org/opencb/opencga/catalog/db/mongodb/MongoDBAdaptorFactory.java
+++ b/opencga-catalog/src/main/java/org/opencb/opencga/catalog/db/mongodb/MongoDBAdaptorFactory.java
@@ -125,6 +125,8 @@ public class MongoDBAdaptorFactory implements DBAdaptorFactory {
                 .add("authenticationDatabase", catalogConfiguration.getCatalog().getDatabase().getOptions().get("authenticationDatabase"))
                 .setConnectionsPerHost(Integer.parseInt(catalogConfiguration.getCatalog().getDatabase().getOptions()
                         .getOrDefault(MongoDBConfiguration.CONNECTIONS_PER_HOST, "20")))
+                .setSslEnabled(Boolean.parseBoolean(catalogConfiguration.getCatalog().getDatabase().getOptions()
+                        .getOrDefault(MongoDBConfiguration.SSL_ENABLED, Boolean.toString(MongoDBConfiguration.SSL_ENABLED_DEFAULT))))
                 .build();
 
         List<DataStoreServerAddress> dataStoreServerAddresses = new LinkedList<>();


### PR DESCRIPTION
This change compliments the changes made in https://github.com/opencb/java-common-libs/pull/39. The `sslEnabled` configuration is now picked up from config to allow SSL connections to MongoDB.

To enable SSL for the catalog, configuration such as the following would be required:

``` yaml
catalog:
  offset: 0
  database:
    hosts:
    - some.mongo.server.example.com:27017
    user: yourUserName
    password: yourSuperSecurePassword
    options:
      authenticationDatabase: admin
      connectionsPerHost: 20
      sslEnabled: true
```