### PR TITLE
Hdinsight cluster name must start with a letter

### DIFF
--- a/opencga-app/app/scripts/azure/arm/hdinsight/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/hdinsight/azuredeploy.json
@@ -145,7 +145,7 @@
             "key": "[parameters('storageAccountKey')]"
 
         }, 
-        "clusterName": "[uniqueString(parameters('clusterNamePrefix'), resourceGroup().id)]"
+        "clusterName": "[concat(parameters('clusterNamePrefix'), uniqueString(resourceGroup().id))]"
 
     },
     "resources": [


### PR DESCRIPTION
uniquestring function should not have included the prefix. This should be joined with the unique string.

@lawrencegripper - as discussed - can you review and merge.
