### PR TITLE
Remove reliance for deployment name for storage account.

### DIFF
--- a/opencga-app/app/scripts/azure/arm/hdinsight-storage/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/hdinsight-storage/azuredeploy.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "storageAccountName": {
-            "defaultValue": "[concat('opencga',uniqueString(resourceGroup().id,deployment().name))]",
+            "defaultValue": "[concat('opencga',uniqueString(resourceGroup().id))]",
             "type": "string"
         },
         "accountType": {


### PR DESCRIPTION
Should not get a new storage account each time deployed, just needs to depend on resource group name.

Closes #1025 