### PR TITLE
WIP: Issue 1051 - Web Server Name Incorrectly Created from Name of Resource Group

### DIFF
--- a/opencga-app/app/scripts/azure/arm/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/azuredeploy.json
@@ -205,7 +205,7 @@
     "variables": {
         "avereEnabled": "[equals(parameters('nfsStorageOption'), 'AvereCluster')]",
         "azureFilesEnabled": "[equals(parameters('nfsStorageOption'), 'AzureFiles')]",
-        "webserverNamingPrefix": "[toLower(substring(concat('webservers', uniqueString(resourceGroup().id)), 0, 16))]"
+        "webserverNamingPrefix": "webservers"
     },
     "resources": [
         {

--- a/opencga-app/app/scripts/azure/arm/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/azuredeploy.json
@@ -205,7 +205,7 @@
     "variables": {
         "avereEnabled": "[equals(parameters('nfsStorageOption'), 'AvereCluster')]",
         "azureFilesEnabled": "[equals(parameters('nfsStorageOption'), 'AzureFiles')]",
-        "webserverNamingPrefix": "[toLower(substring(concat('webservers', uniqueString(parameters('rgPrefix'))), 0, 16))]"
+        "webserverNamingPrefix": "[toLower(substring(concat('webservers', uniqueString(resourceGroup().id)), 0, 16))]"
     },
     "resources": [
         {

--- a/opencga-app/app/scripts/azure/arm/webservers/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/webservers/azuredeploy.json
@@ -136,7 +136,7 @@
             "properties": {
                 "publicIPAllocationMethod": "Static",
                 "dnsSettings": {
-                    "domainNameLabel": "[parameters('publicDnsName')]"
+                    "domainNameLabel": "[variables('publicDnsName')]"
                 }
             }
         },

--- a/opencga-app/app/scripts/azure/arm/webservers/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/webservers/azuredeploy.json
@@ -123,7 +123,8 @@
             ""
         ],
         "cloud-init-string": "[replace(replace(replace(string(variables('cloud-init')),'\",\"','\n'),'[\"',''),'\"]','')]",
-        "customData": "[base64(variables('cloud-init-string'))]"
+        "customData": "[base64(variables('cloud-init-string'))]",
+        "publicDnsName" : "[toLower(substring(concat(parameters('namingPrefix'), uniqueString(resourceGroup().id)), 0, 16))]"
     },
     "resources": [
         {
@@ -135,7 +136,7 @@
             "properties": {
                 "publicIPAllocationMethod": "Static",
                 "dnsSettings": {
-                    "domainNameLabel": "[parameters('namingPrefix')]"
+                    "domainNameLabel": "[parameters('publicDnsName')]"
                 }
             }
         },


### PR DESCRIPTION
Resolves issue #1051 where the DNS name of the web server seems to have been resolved from the name of the Resource Group rather than the ID itself. 

I've only updated the domain label, and kept the rest as a reference to the prefix. 

@lawrencegripper  if it makes more sense, I can update the rest as well