### PR TITLE
Fixes from debugging docker deployments

### DIFF
--- a/opencga-app/app/scripts/docker/opencga-app/Dockerfile
+++ b/opencga-app/app/scripts/docker/opencga-app/Dockerfile
@@ -46,4 +46,4 @@ EXPOSE 8080
 EXPOSE 8443
 
 # Launch Tomcat
-CMD ["./opt/opencga/conf/opencga-env.sh", "&&", "./opt/tomcat/bin/catalina.sh", "run"]
+CMD [". /opt/opencga/conf/opencga-env.sh && /opt/tomcat/bin/catalina.sh run"]

--- a/opencga-app/app/scripts/docker/opencga-app/Dockerfile
+++ b/opencga-app/app/scripts/docker/opencga-app/Dockerfile
@@ -46,4 +46,4 @@ EXPOSE 8080
 EXPOSE 8443
 
 # Launch Tomcat
-CMD ["/opt/tomcat/bin/catalina.sh", "run"]
+CMD ["./opt/opencga/conf/opencga-env.sh", "&&", "./opt/tomcat/bin/catalina.sh", "run"]

--- a/opencga-app/app/scripts/docker/opencga-daemon/Dockerfile
+++ b/opencga-app/app/scripts/docker/opencga-daemon/Dockerfile
@@ -5,4 +5,4 @@ VOLUME /opt/opencga/sessions
 
 USER 1001:1001
 
-CMD ["sh", "-c", "echo ${OPENCGA_PASS} | /opt/opencga/bin/opencga-admin.sh catalog daemon --start"]
+CMD [". /opt/opencga/conf/opencga-env.sh && echo ${OPENCGA_PASS} | /opt/opencga/bin/opencga-admin.sh catalog daemon --start"]

--- a/opencga-app/app/scripts/docker/opencga/Dockerfile
+++ b/opencga-app/app/scripts/docker/opencga/Dockerfile
@@ -13,4 +13,4 @@ RUN apk update && \
 
 COPY ${buildPath} /opt/opencga
 
-ENTRYPOINT [ "/bin/bash" ]
+ENTRYPOINT [ "/bin/bash", "-c" ]

--- a/opencga-app/app/scripts/docker/opencga/Dockerfile
+++ b/opencga-app/app/scripts/docker/opencga/Dockerfile
@@ -3,11 +3,14 @@ FROM openjdk:8-jre-alpine
 ARG buildPath="./build"
 
 WORKDIR /opt/opencga
+ENV BASEDIR=/opt/opencga
 
 RUN adduser -S -u 1001 opencga
 
 RUN apk update && \
-    apk add ca-certificates && \
+    apk add bash ca-certificates && \
     update-ca-certificates
 
 COPY ${buildPath} /opt/opencga
+
+ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
This PR fixes a number of issues we uncovered yesterday:

- Scripts use '/bin/bash/' which wasn't present in our alpine images
- 'opencga-env.sh' wasn't run prior to starting opencga which caused issues
- 'opencga-env.sh' requires 'BASEDIR' to be set otherwise it doesn't update environment variables as expected

Todo:

Current this builds the images but I need to test them. 