### PR TITLE
Changed default storage to SSD for MongoDB

### DIFF
--- a/opencga-app/app/scripts/azure/arm/mongodb/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/mongodb/azuredeploy.json
@@ -153,7 +153,7 @@
                         "osType": "Linux",
                         "createOption": "FromImage",
                         "managedDisk": {
-                            "storageAccountType": "Standard_LRS"
+                            "storageAccountType": "StandardSSD_LRS"
                         }
                     },
                     "imageReference": {


### PR DESCRIPTION
Changed the `storageAccountType` to default to SSD disks for the MongoDB cluster, resolving #1029 