### PR TITLE
Update volume mounts for batch

### DIFF
--- a/opencga-app/app/scripts/azure/arm/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/azuredeploy.json
@@ -399,7 +399,7 @@
                         "value": "[reference('azureBatch').outputs.batchPoolId.value]"
                     },
                     "batchDockerArgs": {
-                        "value": "--mount type=bind,src=/media/primarynfs/conf,dst=/opt/opencga/conf,readonly --mount type=bind,src=/media/primarynfs/sessions,dst=/opt/opencga/sessions --mount type=bind,src=/media/primarynfs/variants,dst=/opt/opencga/variants --rm"
+                        "value": "-v  /media/primarynfs/conf:/opt/opencga/conf -v /media/primarynfs/sessions:/opt/opencga/sessions -v /media/primarynfs/variants:/opt/opencga/variants --rm"
                     },
                     "batchContainerImage": {
                         "value": "[parameters('daemonContainerImage')]"

--- a/opencga-app/app/scripts/docker/opencga-init/setup.sh
+++ b/opencga-app/app/scripts/docker/opencga-init/setup.sh
@@ -41,7 +41,7 @@ python3 /tmp/override-js.py \
 # Copies the config files from our local directory into a
 # persistent volume to be shared by the other containers.
 echo "Initialising volume"
-mkdir -p /opt/volume/conf /opt/volume/sessions
+mkdir -p /opt/volume/conf /opt/volume/sessions /opt/volume/variants
 cp -r /opt/opencga/conf/* /opt/volume/conf
 
 echo "Installing catalog"


### PR DESCRIPTION
The Azure Batch service does not like ```--mount``` so switched for ```-v```.

Also the batch mounts reference a ```variants``` directory which needs to be created as part of opencga-init.