### PR TITLE
Upgrade HDP-2.6.5 version to HDP-2.6.5.3007-2. Fix Hadoop for Datalake Gen2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
                 timeout(time: 30, unit: 'MINUTES')
             }
             steps {
-                sh 'mvn clean install -DskipTests -Dstorage-hadoop -Popencga-storage-hadoop-deps -Phdp-2.6.0 -DOPENCGA.STORAGE.DEFAULT_ENGINE=hadoop -Dopencga.war.name=opencga -Dcheckstyle.skip'
+                sh 'mvn clean install -DskipTests -Dstorage-mongodb -Dstorage-hadoop -Popencga-storage-hadoop-deps -Phdp-2.6.5 -DOPENCGA.STORAGE.DEFAULT_ENGINE=hadoop -Dopencga.war.name=opencga -Dcheckstyle.skip'
             }
         }
 

--- a/opencga-app/app/scripts/docker/build-all.sh
+++ b/opencga-app/app/scripts/docker/build-all.sh
@@ -42,6 +42,7 @@
 # - DOCKER_BUILD_ARGS='' : (optional) Additional build arguments to pass to the docker build command
 # - PUBLISH=''           : (optional) Set to 'true' to publish the docker images to a container registry
 # - TAG=''               : (optional) Set to override the default Git commit SHA docker image tag
+# - HADOOP_FLAVOR='hdp-2.6.5' : (optional) Compile against an specific Hadoop flavour and version
 #
 # When you have set your desired variables, you can simply run the Makefile with `make`.
 
@@ -108,13 +109,14 @@ ENVFILE="${envfile}" make --no-print-directory -f "${dockerDir}/Makefile.docker"
 
 # Build OpenCGA
 if [ ! -d "${buildPath}" ]; then
+    HADOOP_FLAVOR=${HADOOP_FLAVOR:-hdp-2.6.5}
     echo "> No existing OpenCGA build, building from source..."
     docker run -it --rm \
     -v "$PWD":/src \
     -v "$HOME/.m2":/root/.m2 \
     -w /src maven:3.6-jdk-8 \
     mvn -T 1C install \
-    -DskipTests -Dstorage-hadoop -Popencga-storage-hadoop-deps -Phdp-2.6.0 -DOPENCGA.STORAGE.DEFAULT_ENGINE=hadoop -Dopencga.war.name=opencga
+    -DskipTests -Dstorage-hadoop -Popencga-storage-hadoop-deps -P"${HADOOP_FLAVOR}" -DOPENCGA.STORAGE.DEFAULT_ENGINE=hadoop -Dopencga.war.name=opencga
     echo "> Finished OpenCGA build"
 else
     echo "> Using existing OpenCGA build from $PWD/build"

--- a/opencga-storage/opencga-storage-hadoop/pom.xml
+++ b/opencga-storage/opencga-storage-hadoop/pom.xml
@@ -237,7 +237,7 @@
             </activation>
             <properties>
                 <opencga-storage-hadoop-deps.classifier>hdp-2.6.5</opencga-storage-hadoop-deps.classifier>
-                <hdp.dependencies.version>2.6.5.90-1</hdp.dependencies.version>
+                <hdp.dependencies.version>2.6.5.3007-2</hdp.dependencies.version>
 
                 <hadoop.version>2.7.3.${hdp.dependencies.version}</hadoop.version>
                 <hbase.version>1.1.2.${hdp.dependencies.version}</hbase.version>


### PR DESCRIPTION
As discussed, the best way to proceed should be to take the version HDP-2.6.5.3007-2 from the Hortonworks repositories.

- https://github.com/hortonworks/hadoop-release/tree/HDP-2.6.5.3007-2-tag
- http://repo.hortonworks.com/content/repositories/releases/org/apache/hadoop/hadoop-common/2.7.3.2.6.5.3007-2/
- http://repo.hortonworks.com/content/repositories/releases/org/apache/hadoop/hadoop-azure/2.7.3.2.6.5.3007-2/

#### Created jar

```
$ jar -tf opencga-storage-hadoop-core-1.4.0-rc3-dev-jar-with-dependencies.jar  | grep StreamCapabi
org/apache/hadoop/fs/StreamCapabilities$StreamCapability.class
org/apache/hadoop/fs/StreamCapabilitiesPolicy.class
org/apache/hadoop/fs/StreamCapabilities.class

$ jar -tf opencga-storage-hadoop-core-1.4.0-rc3-dev-jar-with-dependencies.jar  | grep AzureBlob
org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem$2.class
org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.class
org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.class
org/apache/hadoop/fs/azurebfs/contracts/exceptions/AzureBlobFileSystemException.class
org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore$VersionedFileStatus.class
org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem$FileSystemOperation.class
org/apache/hadoop/fs/azurebfs/SecureAzureBlobFileSystem.class
org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem$1.class
```


Closes #1069