### PR TITLE
Added runcmd to wait on configuration directories being available

### DIFF
--- a/opencga-app/app/scripts/azure/arm/scripts/wait_config.sh
+++ b/opencga-app/app/scripts/azure/arm/scripts/wait_config.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+MAX_ATTEMPTS=${MAX_ATTEMPTS:-300}
+for i in $(seq 0 "${MAX_ATTEMPTS}");
+do
+    if [ -d "/media/primarynfs/conf/" ];
+    then
+        echo "Configuration is ready";
+        sleep 5; # Give the init configuration 5 seconds to run
+        break;
+    fi;
+    echo "Waiting for configuration... [${i}/${MAX_ATTEMPTS}s]" ;
+    sleep 1;
+done

--- a/opencga-app/app/scripts/azure/arm/webservers/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/webservers/azuredeploy.json
@@ -117,8 +117,8 @@
             "- apt-get update",
             "- curl -fsSL https://get.docker.com/ | sh",
             "- curl -fsSL https://get.docker.com/gpg | sudo apt-key add -",
-            "[concat('- curl -fsSL ', parameters('_artifactsLocation'), '/avere/mount.py', parameters('_artifactsLocationSasToken'), ' | python3 - ', parameters('mountArgs'))]",
-            "[concat('- curl -fsSL ', parameters('_artifactsLocation'), '/scripts/wait_config.sh', parameters('_artifactsLocationSasToken'), ' | bash')]",
+            "[concat('- curl -fsSL ', parameters('_artifactsLocation'), '/avere/mount.py', ' | python3 - ', parameters('mountArgs'))]",
+            "[concat('- curl -fsSL ', parameters('_artifactsLocation'), '/scripts/wait_config.sh', ' | bash')]",
             "[concat('- docker run -d -p 8080:8080 -p 8443:8443 --restart=always --mount type=bind,src=/media/primarynfs/conf,dst=/opt/opencga/conf,readonly --mount type=bind,src=/media/primarynfs/sessions,dst=/opt/opencga/sessions ', parameters('openCGAContainerImage'))]",
             "[concat('- docker run -d -p 80:80 -p 443:443 --restart=always --mount type=bind,src=/media/primarynfs/conf,dst=/opt/opencga/conf,readonly --mount type=bind,src=/media/primarynfs/sessions,dst=/opt/opencga/sessions ', parameters('ivaContainerImage'))]",
             ""

--- a/opencga-app/app/scripts/azure/arm/webservers/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/webservers/azuredeploy.json
@@ -118,6 +118,7 @@
             "- curl -fsSL https://get.docker.com/ | sh",
             "- curl -fsSL https://get.docker.com/gpg | sudo apt-key add -",
             "[concat('- curl -fsSL ', parameters('_artifactsLocation'), '/avere/mount.py', parameters('_artifactsLocationSasToken'), ' | python3 - ', parameters('mountArgs'))]",
+            "[concat('- curl -fsSL ', parameters('_artifactsLocation'), '/scripts/wait_config.sh', parameters('_artifactsLocationSasToken'), ' | bash')]",
             "[concat('- docker run -d -p 8080:8080 -p 8443:8443 --restart=always --mount type=bind,src=/media/primarynfs/conf,dst=/opt/opencga/conf,readonly --mount type=bind,src=/media/primarynfs/sessions,dst=/opt/opencga/sessions ', parameters('openCGAContainerImage'))]",
             "[concat('- docker run -d -p 80:80 -p 443:443 --restart=always --mount type=bind,src=/media/primarynfs/conf,dst=/opt/opencga/conf,readonly --mount type=bind,src=/media/primarynfs/sessions,dst=/opt/opencga/sessions ', parameters('ivaContainerImage'))]",
             ""


### PR DESCRIPTION
This PR aims to address the short term needs of issue #1082.

Notes:
- Only checks `conf` directory
- Waits `5s` after conf directory discovered as a buffer to allow `init-scripts` to run on Daemon - this is a purely huerstic measurement and isn't reliable.
- Is only a temporary fix
- No exit, after 300 iterations the script will try and run the docker containers anyway
- Leaks script level details into the ARM template i.e. the path of the mounts `/media/primarynfs/conf`. If someone changed the script it would break this check.
- WIP: until deployment tested