### PR TITLE
Ensure always 1 VM in batch pool

### DIFF
--- a/opencga-app/app/scripts/azure/arm/azurebatch/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/azurebatch/azuredeploy.json
@@ -147,7 +147,7 @@
                 "scaleSettings": {
                     "autoScale": {
                         "evaluationInterval": "PT5M",
-                        "formula": "[concat('startingNumberOfVMs = 1;maxNumberofVMs = ', parameters('maxNodeCount'), ';pendingTaskSamplePercent = $PendingTasks.GetSamplePercent(160 * TimeInterval_Second);pendingTaskSamples = pendingTaskSamplePercent < 70 ? startingNumberOfVMs : avg($PendingTasks.GetSample(160 * TimeInterval_Second));$TargetDedicatedNodes=min(maxNumberofVMs, pendingTaskSamples);')]"
+                        "formula": "[concat('startingNumberOfVMs = 1;maxNumberofVMs = ', parameters('maxNodeCount'), ';pendingTaskSamplePercent = $PendingTasks.GetSamplePercent(160 * TimeInterval_Second);pendingTaskSamples = pendingTaskSamplePercent < 70 ? startingNumberOfVMs : avg($PendingTasks.GetSample(160 * TimeInterval_Second));$TargetDedicatedNodes=max(1,min(maxNumberofVMs, pendingTaskSamples));')]"
                     }
                 }
             },

--- a/opencga-app/app/scripts/azure/arm/azurebatch/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/azurebatch/azuredeploy.json
@@ -145,6 +145,9 @@
                     }
                 },
                 "scaleSettings": {
+                    "fixedScale": {
+                            "targetDedicatedNodes": 1
+                    },
                     "autoScale": {
                         "evaluationInterval": "PT5M",
                         "formula": "[concat('startingNumberOfVMs = 0;maxNumberofVMs = ', parameters('maxNodeCount'), ';pendingTaskSamplePercent = $PendingTasks.GetSamplePercent(160 * TimeInterval_Second);pendingTaskSamples = pendingTaskSamplePercent < 70 ? startingNumberOfVMs : avg($PendingTasks.GetSample(160 * TimeInterval_Second));$TargetDedicatedNodes=min(maxNumberofVMs, pendingTaskSamples);')]"

--- a/opencga-app/app/scripts/azure/arm/azurebatch/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/azurebatch/azuredeploy.json
@@ -145,12 +145,9 @@
                     }
                 },
                 "scaleSettings": {
-                    "fixedScale": {
-                            "targetDedicatedNodes": 1
-                    },
                     "autoScale": {
                         "evaluationInterval": "PT5M",
-                        "formula": "[concat('startingNumberOfVMs = 0;maxNumberofVMs = ', parameters('maxNodeCount'), ';pendingTaskSamplePercent = $PendingTasks.GetSamplePercent(160 * TimeInterval_Second);pendingTaskSamples = pendingTaskSamplePercent < 70 ? startingNumberOfVMs : avg($PendingTasks.GetSample(160 * TimeInterval_Second));$TargetDedicatedNodes=min(maxNumberofVMs, pendingTaskSamples);')]"
+                        "formula": "[concat('startingNumberOfVMs = 1;maxNumberofVMs = ', parameters('maxNodeCount'), ';pendingTaskSamplePercent = $PendingTasks.GetSamplePercent(160 * TimeInterval_Second);pendingTaskSamples = pendingTaskSamplePercent < 70 ? startingNumberOfVMs : avg($PendingTasks.GetSample(160 * TimeInterval_Second));$TargetDedicatedNodes=min(maxNumberofVMs, pendingTaskSamples);')]"
                     }
                 }
             },


### PR DESCRIPTION
Tried few ways to ensure minimum of one node in the batch pool. Then no need to wait 15mins + for nodes to spin up.

Ended up modifying formula. Feels hacky, @lawrencegripper thoughts?

Could parameterise it.