### PR TITLE
Remove ARM template validation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,15 +2,6 @@ pipeline {
     agent any
     stages {
 
-        stage ('Validate ARM Templates') {
-            options {
-                timeout(time: 5, unit: 'MINUTES')
-            }
-            steps {
-                sh 'cd opencga-app/app/scripts/azure/arm && npm install armval && node node_modules/.bin/armval "**/azuredeploy.json" && rm -rf node_modules && rm -rf package-lock.json'
-            }
-        }
-
         stage ('Build') {
             options {
                 timeout(time: 30, unit: 'MINUTES')


### PR DESCRIPTION
As:
1. There are so many false positives the time to add ignores feels counter productive.
2. Moving to terraform this will become less of an issue.

I think the principle and tool is great, but the schema/language server needs to be accurate. 

Happy to add the ignores if people feel it's a better way forward.