### PR TITLE
Remove git reset from IVA

### DIFF
--- a/opencga-app/app/scripts/docker/iva/Dockerfile
+++ b/opencga-app/app/scripts/docker/iva/Dockerfile
@@ -1,8 +1,5 @@
 FROM httpd
 
-# Minimum compatible git commit, please only use later commits.
-ARG IVA_COMMIT_SHA="dce421b6933d540d9c511c72e63c0e85dff00667"
-
 # Install dependencies
 RUN apt-get update && \
     apt-get upgrade -y && \
@@ -16,7 +13,6 @@ RUN echo '{ "allow_root": true }' > /root/.bowerrc && \
 # Download and extract the IVA configuration into our local configuration
 RUN git clone -b "master" "https://github.com/opencb/iva.git" && \
     cd iva && \
-    git reset "$IVA_COMMIT_SHA" --hard && \
     git submodule update --init && \
     cd lib/jsorolla && \
     git checkout develop && \


### PR DESCRIPTION
IVA did not work on the specifed commit, so now using lastest commit on master, which works.

Also commits shoudl be handled as docker tags, not in the docker file.

