### PR TITLE
Add an ARM template to deploy Terraform

### DIFF
--- a/opencga-app/app/scripts/azure/terraform/.dockerignore
+++ b/opencga-app/app/scripts/azure/terraform/.dockerignore
@@ -1,0 +1,2 @@
+.terraform
+*.tfstate

--- a/opencga-app/app/scripts/azure/terraform/Dockerfile
+++ b/opencga-app/app/scripts/azure/terraform/Dockerfile
@@ -1,5 +1,12 @@
-FROM hashicorp/terraform:light
+FROM microsoft/azure-cli:2.0.57
+
+RUN wget https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_386.zip && \
+    mkdir -p terraform && \
+    unzip terraform_0.11.11_linux_386.zip -d terraform && \
+    mv terraform/terraform /usr/local/bin
 
 COPY . .
 
-RUN terraform init
+RUN chmod +x ./entrypoint.sh
+
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/opencga-app/app/scripts/azure/terraform/Dockerfile
+++ b/opencga-app/app/scripts/azure/terraform/Dockerfile
@@ -1,0 +1,5 @@
+FROM hashicorp/terraform:light
+
+COPY . .
+
+RUN terraform init

--- a/opencga-app/app/scripts/azure/terraform/arm/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/terraform/arm/azuredeploy.json
@@ -1,0 +1,188 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "deployContainerImage": {
+            "type": "string",
+            "defaultValue": "dotjson/aci-tf:test"
+        },
+        "opencgaContainerImage": {
+            "type": "string",
+            "defaultValue": "opencb/opencga-app:c3824d5222c2d21620c281626d10f84f07434773"
+        },
+        "ivaContainerImage": {
+            "type": "string",
+            "defaultValue": "opencb/iva:c3824d5222c2d21620c281626d10f84f07434773"
+        },
+        "initContainerImage": {
+            "type": "string",
+            "defaultValue": "opencb/opencga-init:c3824d5222c2d21620c281626d10f84f07434773"
+        },
+        "batchContainerImage": {
+            "type": "string",
+            "defaultValue": "opencb/opencga-batch:c3824d5222c2d21620c281626d10f84f07434773"
+        },
+        "catalogSecretKey": {
+            "type": "string"
+        },
+        "adminPassword": {
+            "type": "string"
+        },
+        "letsEncryptEmailAddress": {
+            "type": "string"
+        },
+        "sshPubKeyData": {
+            "type": "string"
+        }
+    },
+    "variables": {
+        "containerInstanceName": "[concat(resourceGroup().name, '-aci')]",
+        "identityName": "[concat(resourceGroup().name, '-identity')]",
+        "roleAssignmentId": "[guid(concat(resourceGroup().name, 'owner'))]",
+        "ownerRoleGuid": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+        "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('ownerRoleGuid'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+            "name": "[variables('identityName')]",
+            "apiVersion": "2015-08-31-preview",
+            "location": "[resourceGroup().location]"
+        },
+        {
+            "comments": "Only included to delay role assignment long enough to allow AAD propagation",
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[concat('delay', uniquestring(resourceGroup().id))]",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2018-07-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]"
+            ],
+            "sku": {
+                "name": "Standard_LRS"
+            },
+            "kind": "StorageV2",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2017-05-01",
+            "name": "[variables('roleAssignmentId')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', concat('delay', uniquestring(resourceGroup().id)))]",
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('roleDefinitionId')]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName')), '2015-08-31-preview').principalId]",
+                "scope": "[resourceGroup().id]"
+            }
+        },
+        {
+            "type": "Microsoft.ContainerInstance/containerGroups",
+            "apiVersion": "2018-10-01",
+            "name": "[variables('containerInstanceName')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]",
+                "[resourceId('Microsoft.Authorization/roleAssignments', variables('roleAssignmentId'))]"
+            ],
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]": {}
+                }
+            },
+            "properties": {
+                "osType": "Linux",
+                "restartPolicy": "OnFailure",
+                "containers": [
+                    {
+                        "name": "terraform",
+                        "properties": {
+                            "image": "[parameters('deployContainerImage')]",
+                            "environmentVariables": [
+                                {
+                                    "name": "ARM_SKIP_CREDENTIALS_VALIDATION",
+                                    "value": true
+                                },
+                                {
+                                    "name": "ARM_SKIP_PROVIDER_REGISTRATION",
+                                    "value": true
+                                },
+                                {
+                                    "name": "ARM_USE_MSI",
+                                    "value": true
+                                },
+                                {
+                                    "name": "ARM_MSI_ENDPOINT",
+                                    "value": "http://169.254.169.254/metadata/identity/oauth2/token"
+                                },
+                                {
+                                    "name": "ARM_SUBSCRIPTION_ID",
+                                    "value": "[subscription().subscriptionId]"
+                                },
+                                {
+                                    "name": "ARM_TENANT_ID",
+                                    "value": "[subscription().tenantId]"
+                                },
+                                {
+                                    "name": "TF_VAR_location",
+                                    "value": "[resourceGroup().location]"
+                                },
+                                {
+                                    "name": "TF_VAR_opencga_image",
+                                    "value": "[parameters('opencgaContainerImage')]"
+                                },
+                                {
+                                    "name": "TF_VAR_iva_image",
+                                    "value": "[parameters('ivaContainerImage')]"
+                                },
+                                {
+                                    "name": "TF_VAR_opencga_init_image",
+                                    "value": "[parameters('initContainerImage')]"
+                                },
+                                {
+                                    "name": "TF_VAR_batch_container_image",
+                                    "value": "[parameters('batchContainerImage')]"
+                                },
+                                {
+                                    "name": "TF_VAR_catalog_secret_key",
+                                    "value": "[parameters('catalogSecretKey')]"
+                                },
+                                {
+                                    "name": "TF_VAR_opencga_admin_password",
+                                    "value": "[parameters('adminPassword')]"
+                                },
+                                {
+                                    "name": "TF_VAR_lets_encrypt_email_address",
+                                    "value": "[parameters('letsEncryptEmailAddress')]"
+                                },
+                                {
+                                    "name": "TF_VAR_lets_resource_group_prefix",
+                                    "value": "[resourceGroup().name]"
+                                },
+                                {
+                                    "name": "TF_VAR_ssh_pub_key",
+                                    "value": "[parameters('sshPubKeyData')]"
+                                }
+                            ],
+                            "command": [
+                                "terraform",
+                                "apply",
+                                "-auto-approve"
+                            ],
+                            "resources": {
+                                "requests": {
+                                    "cpu": 1,
+                                    "memoryInGB": 1
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/opencga-app/app/scripts/azure/terraform/arm/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/terraform/arm/azuredeploy.json
@@ -4,7 +4,7 @@
     "parameters": {
         "deployContainerImage": {
             "type": "string",
-            "defaultValue": "dotjson/aci-tf:test"
+            "defaultValue": "dotjson/aci-tf:test1"
         },
         "opencgaContainerImage": {
             "type": "string",
@@ -36,6 +36,9 @@
         }
     },
     "variables": {
+        "storageAccountName": "[concat('tfstate', uniquestring(resourceGroup().id))]",
+        "storageContainerName": "terraform",
+        "tfstateBlobName": "terraform.tfstate",
         "containerInstanceName": "[concat(resourceGroup().name, '-aci')]",
         "identityName": "[concat(resourceGroup().name, '-identity')]",
         "roleAssignmentId": "[guid(concat(resourceGroup().name, 'contributor'))]",
@@ -50,9 +53,8 @@
             "location": "[resourceGroup().location]"
         },
         {
-            "comments": "Only included to delay role assignment long enough to allow AAD propagation",
             "type": "Microsoft.Storage/storageAccounts",
-            "name": "[concat('delay', uniquestring(resourceGroup().id))]",
+            "name": "[variables('storageAccountName')]",
             "location": "[resourceGroup().location]",
             "apiVersion": "2018-07-01",
             "dependsOn": [
@@ -69,7 +71,7 @@
             "apiVersion": "2017-05-01",
             "name": "[variables('roleAssignmentId')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', concat('delay', uniquestring(resourceGroup().id)))]",
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]"
             ],
             "properties": {
@@ -152,7 +154,7 @@
                                 },
                                 {
                                     "name": "TF_VAR_opencga_admin_password",
-                                    "value": "[parameters('adminPassword')]"
+                                    "secureValue": "[parameters('adminPassword')]"
                                 },
                                 {
                                     "name": "TF_VAR_lets_encrypt_email_address",
@@ -169,12 +171,27 @@
                                 {
                                     "name": "TF_VAR_existing_resource_group",
                                     "value": true
+                                },
+                                {
+                                    "name": "ARM_IDENTITY",
+                                    "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]"
+                                },
+                                {
+                                    "name": "TF_VAR_state_storage_container_name",
+                                    "value": "[variables('storageContainerName')]"
+                                },
+                                {
+                                    "name": "TF_VAR_state_storage_account_name",
+                                    "value": "[variables('storageAccountName')]"
+                                },
+                                {
+                                    "name": "TF_VAR_state_storage_account_key",
+                                    "secureValue": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
+                                },
+                                {
+                                    "name": "TF_VAR_state_storage_blob_name",
+                                    "value": "[variables('tfstateBlobName')]"
                                 }
-                            ],
-                            "command": [
-                                "terraform",
-                                "apply",
-                                "-auto-approve"
                             ],
                             "resources": {
                                 "requests": {
@@ -188,5 +205,22 @@
             }
         }
     ],
-    "outputs": {}
+    "outputs": {
+        "tfstateStorageAccountName": {
+            "type": "string",
+            "value": "[variables('storageAccountName')]"
+        },
+        "tfstateStorageAccountKey": {
+            "type": "securestring",
+            "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
+        },
+        "tfstateContainerName": {
+            "type": "string",
+            "value": "[variables('storageContainerName')]"
+        },
+        "tfstateBlobName": {
+            "type": "string",
+            "value": "[variables('tfstateBlobName')]"
+        }
+    }
 }

--- a/opencga-app/app/scripts/azure/terraform/arm/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/terraform/arm/azuredeploy.json
@@ -38,9 +38,9 @@
     "variables": {
         "containerInstanceName": "[concat(resourceGroup().name, '-aci')]",
         "identityName": "[concat(resourceGroup().name, '-identity')]",
-        "roleAssignmentId": "[guid(concat(resourceGroup().name, 'owner'))]",
-        "ownerRoleGuid": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
-        "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('ownerRoleGuid'))]"
+        "roleAssignmentId": "[guid(concat(resourceGroup().name, 'contributor'))]",
+        "contributorRoleGuid": "b24988ac-6180-42a0-ab88-20f7382dd24c",
+        "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', variables('contributorRoleGuid'))]"
     },
     "resources": [
         {
@@ -159,12 +159,16 @@
                                     "value": "[parameters('letsEncryptEmailAddress')]"
                                 },
                                 {
-                                    "name": "TF_VAR_lets_resource_group_prefix",
+                                    "name": "TF_VAR_resource_group_prefix",
                                     "value": "[resourceGroup().name]"
                                 },
                                 {
                                     "name": "TF_VAR_ssh_pub_key",
                                     "value": "[parameters('sshPubKeyData')]"
+                                },
+                                {
+                                    "name": "TF_VAR_existing_resource_group",
+                                    "value": true
                                 }
                             ],
                             "command": [

--- a/opencga-app/app/scripts/azure/terraform/arm/azuredeploy.parameters.json
+++ b/opencga-app/app/scripts/azure/terraform/arm/azuredeploy.parameters.json
@@ -12,7 +12,7 @@
             "value": ""
         },
         "sshPubKeyData": {
-            "type": "string"
+            "value": ""
         }
     }
 }

--- a/opencga-app/app/scripts/azure/terraform/arm/azuredeploy.parameters.json
+++ b/opencga-app/app/scripts/azure/terraform/arm/azuredeploy.parameters.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "catalogSecretKey": {
+            "value": ""
+        },
+        "adminPassword": {
+            "value": ""
+        },
+        "letsEncryptEmailAddress": {
+            "value": ""
+        },
+        "sshPubKeyData": {
+            "type": "string"
+        }
+    }
+}

--- a/opencga-app/app/scripts/azure/terraform/azurebatch/batch.tf
+++ b/opencga-app/app/scripts/azure/terraform/azurebatch/batch.tf
@@ -14,7 +14,12 @@ variable "mount_args" {
   type = "string"
 }
 
+variable "create_resource_group" {
+  default = true
+}
+
 resource "azurerm_resource_group" "batch" {
+  count    = "${var.create_resource_group}"
   name     = "${var.resource_group_name}"
   location = "${var.location}"
 }
@@ -50,8 +55,8 @@ resource "random_string" "batch_name" {
 
 resource "azurerm_storage_account" "storage" {
   name                     = "${random_string.storage_name.result}"
-  resource_group_name      = "${azurerm_resource_group.batch.name}"
-  location                 = "${azurerm_resource_group.batch.location}"
+  resource_group_name      = "${var.create_resource_group ? join("", azurerm_resource_group.batch.*.name) : var.resource_group_name}"
+  location                 = "${var.location}"
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
@@ -77,12 +82,10 @@ resource "azurerm_template_deployment" "batchpool" {
 
 output "batch_account_endpoint" {
   value = "${azurerm_template_deployment.batchpool.outputs["batchEndpoint"]}"
-
 }
 
 output "batch_account_name" {
   value = "${azurerm_template_deployment.batchpool.outputs["batchAccountName"]}"
-
 }
 
 output "batch_account_pool_id" {

--- a/opencga-app/app/scripts/azure/terraform/azurefiles/main.tf
+++ b/opencga-app/app/scripts/azure/terraform/azurefiles/main.tf
@@ -6,7 +6,12 @@ variable "resource_group_name" {
   type = "string"
 }
 
+variable "create_resource_group" {
+  default = true
+}
+
 resource "azurerm_resource_group" "storage" {
+  count = "${var.create_resource_group}"
   name     = "${var.resource_group_name}"
   location = "${var.location}"
 }
@@ -27,7 +32,7 @@ resource "random_string" "storage_name" {
 
 resource "azurerm_storage_account" "storage" {
   name                     = "${random_string.storage_name.result}"
-  resource_group_name      = "${azurerm_resource_group.storage.name}"
+  resource_group_name      = "${var.create_resource_group ? join("", azurerm_resource_group.storage.*.name) : var.resource_group_name}"
   location                 = "${var.location}"
   account_tier             = "Standard"
   account_replication_type = "LRS"
@@ -36,7 +41,7 @@ resource "azurerm_storage_account" "storage" {
 resource "azurerm_storage_share" "share" {
   name = "opencgashare"
 
-  resource_group_name  = "${azurerm_resource_group.storage.name}"
+  resource_group_name  = "${var.create_resource_group ? join("", azurerm_resource_group.storage.*.name) : var.resource_group_name}"
   storage_account_name = "${azurerm_storage_account.storage.name}"
 
   quota = 50

--- a/opencga-app/app/scripts/azure/terraform/entrypoint.sh
+++ b/opencga-app/app/scripts/azure/terraform/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+echo "---"
+echo " Logging in with Managed Service Identity"
+echo "---"
+az login --identity -u "${ARM_IDENTITY}"
+
+echo "---"
+echo "Create Azure Blob Storage container if it doesn't exist"
+echo "---"
+az storage container create --name "${TF_VAR_state_storage_container_name}" --account-name "${TF_VAR_state_storage_account_name}" --account-key "${TF_VAR_state_storage_account_key}"
+
+export ARM_ACCESS_KEY="${TF_VAR_state_storage_account_key}"
+
+echo "---"
+echo "Initializing terraform"
+echo "---"
+terraform init \
+    -backend-config "storage_account_name=$TF_VAR_state_storage_account_name" \
+    -backend-config "container_name=$TF_VAR_state_storage_container_name" \
+    -backend-config "key=$TF_VAR_state_storage_blob_name"
+
+echo "---"
+echo "Applying terraform"
+echo "---"
+terraform apply -auto-approve

--- a/opencga-app/app/scripts/azure/terraform/hdinsight/armwrapper.tf
+++ b/opencga-app/app/scripts/azure/terraform/hdinsight/armwrapper.tf
@@ -14,7 +14,12 @@ variable "resource_group_name" {
   type = "string"
 }
 
+variable "create_resource_group" {
+  default = true
+}
+
 resource "azurerm_resource_group" "hdinsight-rg" {
+  count    = "${var.create_resource_group}"
   name     = "${var.resource_group_name}"
   location = "${var.location}"
 }

--- a/opencga-app/app/scripts/azure/terraform/main.tf
+++ b/opencga-app/app/scripts/azure/terraform/main.tf
@@ -15,6 +15,24 @@ variable "lets_encrypt_email_address" {
 variable "resource_group_prefix" {
   default = "opencga"
 }
+variable "state_storage_account_name" {}
+variable "state_storage_container_name" {}
+variable "state_storage_blob_name" {
+  default = "terraform.tfstate"
+}
+
+terraform {
+  backend "azurerm" {}
+}
+
+data "terraform_remote_state" "state" {
+  backend = "azurerm"
+  config {
+    storage_account_name  = "${var.state_storage_account_name}"
+    container_name        = "${var.state_storage_container_name}"
+    key                   = "${var.state_storage_blob_name}"
+  }
+}
 
 // Pin to a version of the terraform provider to prevent breaking changes of future releases
 // work should be undertaken to update this from time-to-time to track the lastest release

--- a/opencga-app/app/scripts/azure/terraform/main.tf
+++ b/opencga-app/app/scripts/azure/terraform/main.tf
@@ -6,11 +6,12 @@ variable "batch_container_image" {}
 variable "catalog_secret_key" {}
 variable "opencga_admin_password" {}
 variable "ssh_pub_key" {}
-
+variable "existing_resource_group" {
+  default = false
+}
 variable "lets_encrypt_email_address" {
   description = "This is the email address used when obtaining SSL certs for the solution. This should be a valid email for the solution admin."
 }
-
 variable "resource_group_prefix" {
   default = "opencga"
 }
@@ -21,7 +22,16 @@ provider "azurerm" {
   version = "=1.21.0"
 }
 
+locals {
+  hdinsight_resource_group_name = "${var.existing_resource_group ? var.resource_group_prefix : format("%s-%s", var.resource_group_prefix,"hdinsight")}"
+  storage_resource_group_name = "${var.existing_resource_group ? var.resource_group_prefix : format("%s-%s", var.resource_group_prefix,"storage")}"
+  batch_resource_group_name = "${var.existing_resource_group ? var.resource_group_prefix : format("%s-%s", var.resource_group_prefix,"batch")}"
+  mongo_resource_group_name = "${var.existing_resource_group ? var.resource_group_prefix : format("%s-%s", var.resource_group_prefix,"mongo")}"
+  web_resource_group_name = "${var.existing_resource_group ? var.resource_group_prefix : format("%s-%s", var.resource_group_prefix,"web")}"
+}
+
 resource "azurerm_resource_group" "opencga" {
+  count = "${var.existing_resource_group ? 0 : 1}"
   name     = "${var.resource_group_prefix}"
   location = "${var.location}"
 }
@@ -33,21 +43,24 @@ module "hdinsight" {
   virtual_network_subnet_id = "${azurerm_subnet.hdinsight.id}"
 
   location            = "${var.location}"
-  resource_group_name = "${var.resource_group_prefix}-hdinsight"
+  resource_group_name = "${local.hdinsight_resource_group_name}"
+  create_resource_group = "${var.existing_resource_group ? 0 : 1}"
 }
 
 module "azurefiles" {
   source = "./azurefiles"
 
   location            = "${var.location}"
-  resource_group_name = "${var.resource_group_prefix}-storage"
+  resource_group_name = "${local.storage_resource_group_name}"
+  create_resource_group = "${var.existing_resource_group ? 0 : 1}"
 }
 
 module "azurebatch" {
   source = "./azurebatch"
 
   location            = "${var.location}"
-  resource_group_name = "${var.resource_group_prefix}-batch"
+  resource_group_name = "${local.batch_resource_group_name}"
+  create_resource_group = "${var.existing_resource_group ? 0 : 1}"
 
   virtual_network_subnet_id = "${azurerm_subnet.batch.id}"
 
@@ -58,7 +71,8 @@ module "mongo" {
   source = "./mongo"
 
   location            = "${var.location}"
-  resource_group_name = "${var.resource_group_prefix}-mongo"
+  resource_group_name = "${local.mongo_resource_group_name}"
+  create_resource_group = "${var.existing_resource_group ? 0 : 1}"
 
   virtual_network_subnet_id = "${azurerm_subnet.mongo.id}"
   admin_username            = "opencga"
@@ -71,7 +85,7 @@ module "mongo" {
 resource "random_string" "webservers_dns_prefix" {
   keepers = {
     # Generate a new id each time we switch to a new resource group
-    group_name = "${var.resource_group_prefix}-web"
+    group_name = "${local.web_resource_group_name}"
   }
 
   length  = 8
@@ -88,7 +102,8 @@ module "webservers" {
   source = "./webservers"
 
   location            = "${var.location}"
-  resource_group_name = "${var.resource_group_prefix}-web"
+  resource_group_name = "${local.web_resource_group_name}"
+  create_resource_group = "${var.existing_resource_group ? 0 : 1}"
 
   virtual_network_subnet_id = "${azurerm_subnet.web.id}"
 
@@ -161,6 +176,7 @@ module "daemonvm" {
 
   location            = "${var.location}"
   resource_group_name = "${var.resource_group_prefix}"
+  create_resource_group = "${var.existing_resource_group ? 0 : 1}"
 
   virtual_network_subnet_id = "${azurerm_subnet.daemonvm.id}"
 

--- a/opencga-app/app/scripts/azure/terraform/main.tf
+++ b/opencga-app/app/scripts/azure/terraform/main.tf
@@ -3,10 +3,9 @@ variable "opencga_image" {}
 variable "iva_image" {}
 variable "opencga_init_image" {}
 variable "batch_container_image" {}
-
 variable "catalog_secret_key" {}
-
 variable "opencga_admin_password" {}
+variable "ssh_pub_key" {}
 
 variable "lets_encrypt_email_address" {
   description = "This is the email address used when obtaining SSL certs for the solution. This should be a valid email for the solution admin."
@@ -63,7 +62,7 @@ module "mongo" {
 
   virtual_network_subnet_id = "${azurerm_subnet.mongo.id}"
   admin_username            = "opencga"
-  ssh_key_data              = "${file("~/.ssh/id_rsa.pub")}"
+  ssh_key_data              = "${var.ssh_pub_key}"
 
   email_address = "${var.lets_encrypt_email_address}"
   cluster_size  = 3
@@ -96,7 +95,7 @@ module "webservers" {
   mount_args = "azurefiles ${module.azurefiles.storage_account_name},${module.azurefiles.share_name},${module.azurefiles.storage_key}"
 
   admin_username = "opencga"
-  ssh_key_data   = "${file("~/.ssh/id_rsa.pub")}"
+  ssh_key_data   = "${var.ssh_pub_key}"
 
   opencga_image = "${var.opencga_image}"
   iva_image     = "${var.iva_image}"
@@ -168,7 +167,7 @@ module "daemonvm" {
   mount_args = "azurefiles ${module.azurefiles.storage_account_name},${module.azurefiles.share_name},${module.azurefiles.storage_key}"
 
   admin_username = "opencga"
-  ssh_key_data   = "${file("~/.ssh/id_rsa.pub")}"
+  ssh_key_data   = "${var.ssh_pub_key}"
 
   opencga_image          = "${var.opencga_image}"
   opencga_init_image     = "${var.opencga_init_image}"

--- a/opencga-app/app/scripts/azure/terraform/network.tf
+++ b/opencga-app/app/scripts/azure/terraform/network.tf
@@ -1,20 +1,20 @@
 resource "azurerm_virtual_network" "opencga" {
   name                = "opencga-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.opencga.location}"
-  resource_group_name = "${azurerm_resource_group.opencga.name}"
+  location            = "${var.location}"
+  resource_group_name = "${var.existing_resource_group ? var.resource_group_prefix : join("", azurerm_resource_group.opencga.*.name)}"
 }
 
 resource "azurerm_subnet" "web" {
   name                 = "webservers"
-  resource_group_name  = "${azurerm_resource_group.opencga.name}"
+  resource_group_name  = "${var.existing_resource_group ? var.resource_group_prefix : join("", azurerm_resource_group.opencga.*.name)}"
   virtual_network_name = "${azurerm_virtual_network.opencga.name}"
   address_prefix       = "10.0.0.0/24"
 }
 
 resource "azurerm_subnet" "hdinsight" {
   name                 = "hdinsight"
-  resource_group_name  = "${azurerm_resource_group.opencga.name}"
+  resource_group_name  = "${var.existing_resource_group ? var.resource_group_prefix : join("", azurerm_resource_group.opencga.*.name)}"
   virtual_network_name = "${azurerm_virtual_network.opencga.name}"
   address_prefix       = "10.0.1.0/24"
   service_endpoints    = ["Microsoft.Storage"]
@@ -22,35 +22,35 @@ resource "azurerm_subnet" "hdinsight" {
 
 resource "azurerm_subnet" "mongo" {
   name                 = "mongo"
-  resource_group_name  = "${azurerm_resource_group.opencga.name}"
+  resource_group_name  = "${var.existing_resource_group ? var.resource_group_prefix : join("", azurerm_resource_group.opencga.*.name)}"
   virtual_network_name = "${azurerm_virtual_network.opencga.name}"
   address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_subnet" "solr" {
   name                 = "solr"
-  resource_group_name  = "${azurerm_resource_group.opencga.name}"
+  resource_group_name  = "${var.existing_resource_group ? var.resource_group_prefix : join("", azurerm_resource_group.opencga.*.name)}"
   virtual_network_name = "${azurerm_virtual_network.opencga.name}"
   address_prefix       = "10.0.3.0/24"
 }
 
 resource "azurerm_subnet" "batch" {
   name                 = "batch"
-  resource_group_name  = "${azurerm_resource_group.opencga.name}"
+  resource_group_name  = "${var.existing_resource_group ? var.resource_group_prefix : join("", azurerm_resource_group.opencga.*.name)}"
   virtual_network_name = "${azurerm_virtual_network.opencga.name}"
   address_prefix       = "10.0.4.0/24"
 }
 
 resource "azurerm_subnet" "avere" {
   name                 = "avere"
-  resource_group_name  = "${azurerm_resource_group.opencga.name}"
+  resource_group_name  = "${var.existing_resource_group ? var.resource_group_prefix : join("", azurerm_resource_group.opencga.*.name)}"
   virtual_network_name = "${azurerm_virtual_network.opencga.name}"
   address_prefix       = "10.0.5.0/24"
 }
 
 resource "azurerm_subnet" "daemonvm" {
   name                 = "daemonvm"
-  resource_group_name  = "${azurerm_resource_group.opencga.name}"
+  resource_group_name  = "${var.existing_resource_group ? var.resource_group_prefix : join("", azurerm_resource_group.opencga.*.name)}"
   virtual_network_name = "${azurerm_virtual_network.opencga.name}"
   address_prefix       = "10.0.6.0/24"
 }


### PR DESCRIPTION
Add a simple terraform template that uses ACI to deploy a `terraform` templates that will actually deploy the OpenCGA solution into Azure. This "trick" is needed to allow us to deploy it to the Azure marketplace. This branch is experimental and we're not sure if we'll be able to get all the functionality we need.

05/02/2019 - Status: currently deploying but as the `terraform` tries to spin up new resource groups which is outside the scope of the managed service identity we are using we get 403s. We'll need to condense the solution down to a single resource group to be able to get around this as you cannot assign subscription level MSI scope via an ARM template defined MSI.

06/02/2019 - Status: Modified Terraform and ARM templates to support a single resource group deployment which appears to be working as expected. Need to decide what output parameters would be required and how to surface them. Likely we'd need to build the parameters in the ARM and pass them through to the TF to be able to output them from the ARM.