### PR TITLE
Change SOLR disk to SSD and set heap size

### DIFF
--- a/opencga-app/app/scripts/azure/arm/armvalconfig.json
+++ b/opencga-app/app/scripts/azure/arm/armvalconfig.json
@@ -42,6 +42,15 @@
             {
                 "message": ".*",
                 "resource": {
+                    "type": "Microsoft.Compute/virtualMachines",
+                    "apiVersion": "2018-06-01",
+                    "name": ".*"
+                },
+                "reason": "Global deployment schema invalid"
+            },
+            {
+                "message": ".*",
+                "resource": {
                     "apiVersion": "2017-04-26-preview",
                     "type": "Microsoft.OperationalInsights/workspaces",
                     "name": "[parameters('WorkspaceName')]"

--- a/opencga-app/app/scripts/azure/arm/armvalconfig.json
+++ b/opencga-app/app/scripts/azure/arm/armvalconfig.json
@@ -42,15 +42,6 @@
             {
                 "message": ".*",
                 "resource": {
-                    "type": "Microsoft.Compute/virtualMachines",
-                    "apiVersion": "2018-06-01",
-                    "name": ".*"
-                },
-                "reason": "Global deployment schema invalid"
-            },
-            {
-                "message": ".*",
-                "resource": {
                     "apiVersion": "2017-04-26-preview",
                     "type": "Microsoft.OperationalInsights/workspaces",
                     "name": "[parameters('WorkspaceName')]"

--- a/opencga-app/app/scripts/azure/arm/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/azuredeploy.json
@@ -85,10 +85,11 @@
         },
         "solrDiskType": {
             "type": "string",
-            "defaultValue": "Standard_LRS",
+            "defaultValue": "StandardSSD_LRS",
             "allowedValues": [
                 "Standard_LRS",
-                "Premium_LRS"
+                "Premium_LRS",
+                "StandardSSD_LRS"
             ],
             "metadata": {
                 "description": "Storage Account type"

--- a/opencga-app/app/scripts/azure/arm/mongodb/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/mongodb/azuredeploy.json
@@ -233,7 +233,10 @@
                         {
                             "diskSizeGB": 1023,
                             "lun": 0,
-                            "createOption": "Empty"
+                            "createOption": "Empty",
+                            "managedDisk": {
+                                "storageAccountType": "StandardSSD_LRS"
+                            }
                         }
                     ],
                     "imageReference": {

--- a/opencga-app/app/scripts/azure/arm/solr/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/solr/azuredeploy.json
@@ -281,7 +281,7 @@
     ]
     },
     {
-      "apiVersion": "2018-04-01",
+      "apiVersion": "2018-06-01",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmNames')[copyIndex()].vmName]",
       "location": "[parameters('location')]",

--- a/opencga-app/app/scripts/azure/arm/solr/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/solr/azuredeploy.json
@@ -4,10 +4,11 @@
   "parameters": {
     "diskType": {
       "type": "string",
-      "defaultValue": "Standard_LRS",
+      "defaultValue": "StandardSSD_LRS",
       "allowedValues": [
         "Standard_LRS",
-        "Premium_LRS"
+        "Premium_LRS",
+        "StandardSSD_LRS"
       ],
       "metadata": {
         "description": "Storage Account type"

--- a/opencga-app/app/scripts/azure/arm/solr/azuredeploy.json
+++ b/opencga-app/app/scripts/azure/arm/solr/azuredeploy.json
@@ -281,7 +281,7 @@
     ]
     },
     {
-      "apiVersion": "2017-03-30",
+      "apiVersion": "2018-04-01",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmNames')[copyIndex()].vmName]",
       "location": "[parameters('location')]",
@@ -331,7 +331,17 @@
             "managedDisk": {
               "storageAccountType": "[parameters('diskType')]"
             }
-          }
+          },
+          "dataDisks": [
+            {
+                "diskSizeGB": 1023,
+                "lun": 0,
+                "createOption": "Empty",
+                "managedDisk": {
+                    "storageAccountType": "StandardSSD_LRS"
+                }
+            }
+          ]
         },
         "networkProfile": {
           "networkInterfaces": [

--- a/opencga-app/app/scripts/azure/arm/solr/solr-setup.sh
+++ b/opencga-app/app/scripts/azure/arm/solr/solr-setup.sh
@@ -14,27 +14,63 @@ SOLR_VERSION=$3
 
 DOCKER_NAME=opencga-solr-${SOLR_VERSION}
 
-# Create docker
+
+scanForNewDisks() {
+    # Looks for unpartitioned disks
+    DEVS=($(fdisk -l 2>/dev/null | egrep -o '(/dev/[^:]*):' | egrep -o '([^:]*)'))
+
+    for DEV in "${DEVS[@]}";
+    do
+        echo "Found unpartitioned disk $DEV"
+        isPartitioned ${DEV}
+    done
+}
+
+isPartitioned() {
+    OUTPUT=$(partx -s ${1} 2>&1)
+    if [[ "$OUTPUT" == *"failed to read partition table"* ]]; then
+        # found unpartitioned disk
+        formatAndMountDisk "${DEV}"
+    fi
+}
+
+formatAndMountDisk() {
+    #partitions primary linux partition on new disk
+    echo "Partitioning disk"
+    echo 'type=83' | sfdisk ${1}
+    until blkid ${1}1
+    do
+        echo "Waiting for drive to be partitioned"
+        sleep 2
+    done
+    echo "Formatting Partition"
+    mkfs -t ext4 ${1}1
+    mkdir /datadrive
+    mount -o acl ${1}1 /datadrive
+    fs_uuid=$(blkid -o value -s UUID ${1}1)
+    echo "UUID=${fs_uuid}   /datadrive   ext4   defaults,nofail,acl   1   2" >> /etc/fstab
+}
+
+scanForNewDisks
 
 # Add OpenCGA Configuration Set 
 tar zxfv OpenCGAConfSet-1.4.0.tar.gz
 
 # create a directory to store the server/solr directory
-mkdir /opt/solr-volume
+mkdir /datadrive/solr-volume
 
 # make sure its host owner matches the container's solr user
-sudo chown 8983:8983 /opt/solr-volume
+sudo chown 8983:8983 /datadrive/solr-volume
 
 # copy the solr directory from a temporary container to the volume
-docker run --rm -v /opt/solr-volume:/target solr:${SOLR_VERSION} cp -r server/solr /target/
+docker run --rm -v /datadrive/solr-volume:/target solr:${SOLR_VERSION} cp -r server/solr /target/
 
 # copy configset to volume ready to mount
-cp -r OpenCGAConfSet-1.4.0 /opt/solr-volume/solr/configsets/OpenCGAConfSet-1.4.0
+cp -r OpenCGAConfSet-1.4.0 /datadrive/solr-volume/solr/configsets/OpenCGAConfSet-1.4.0
 
 # get script
 docker run  --rm  solr:${SOLR_VERSION}  cat /opt/solr/bin/solr.in.sh > /opt/solr.in.sh
 
-# botch - give networking a chance!
 
 ZK_CLI=
 if [[ $ZK_HOSTS_NUM -gt 0 ]]; then
@@ -73,7 +109,7 @@ echo 'SOLR_MODE="solrcloud"' >> /opt/solr.in.sh
 TOTAL_RAM=$(sed 's/ kB//g'  <<< $(grep -oP '^MemTotal:\s+\K.*' /proc/meminfo))
 SOLR_HEAP=$(echo "$TOTAL_RAM/1024/1024/2" | bc )
 
-docker run --name ${DOCKER_NAME} --restart always -p 8983:8983 -d -v /opt/solr-volume/solr:/opt/solr/server/solr -v /opt/solr.in.sh:/opt/solr/bin/solr.in.sh -e SOLR_HEAP=${SOLR_HEAP}g  solr:${SOLR_VERSION} docker-entrypoint.sh solr-foreground -h $(hostname) 
+docker run --name ${DOCKER_NAME} --restart always -p 8983:8983 -d -v /datadrive/solr-volume/solr:/opt/solr/server/solr -v /opt/solr.in.sh:/opt/solr/bin/solr.in.sh -e SOLR_HEAP=${SOLR_HEAP}g  solr:${SOLR_VERSION} docker-entrypoint.sh solr-foreground -h $(hostname) 
 
 
 until $(curl --output /dev/null --silent --head --fail  "http://$(hostname):8983/solr/#/offers"); do

--- a/opencga-app/app/scripts/azure/arm/solr/solr-setup.sh
+++ b/opencga-app/app/scripts/azure/arm/solr/solr-setup.sh
@@ -70,8 +70,10 @@ fi
 ## Ensure always using cloud mode, even for the single server configurations.
 echo 'SOLR_MODE="solrcloud"' >> /opt/solr.in.sh
 
+TOTAL_RAM=$(sed 's/ kB//g'  <<< $(grep -oP '^MemTotal:\s+\K.*' /proc/meminfo))
+SOLR_HEAP=$(echo "$TOTAL_RAM/1024/1024/2" | bc )
 
-docker run --name ${DOCKER_NAME} --restart always -p 8983:8983 -d -v /opt/solr-volume/solr:/opt/solr/server/solr -v /opt/solr.in.sh:/opt/solr/bin/solr.in.sh   solr:${SOLR_VERSION} docker-entrypoint.sh solr-foreground -h $(hostname) 
+docker run --name ${DOCKER_NAME} --restart always -p 8983:8983 -d -v /opt/solr-volume/solr:/opt/solr/server/solr -v /opt/solr.in.sh:/opt/solr/bin/solr.in.sh -e SOLR_HEAP=${SOLR_HEAP}g  solr:${SOLR_VERSION} docker-entrypoint.sh solr-foreground -h $(hostname) 
 
 
 until $(curl --output /dev/null --silent --head --fail  "http://$(hostname):8983/solr/#/offers"); do


### PR DESCRIPTION
Fixes #1186 #1183 and changed Mongo DB data disk to SSD.

Deployed, tested as far as docker logs for solr and data location.

One thing to note is I have used StandardSSD_LRS wich is up to 500 iops and 60MiB/s for a 1 TB disk

We could change VM to 'Es' and a Premium SSD which is up to 5000 iops and 200MiB/s for a 1TB disk.

Larger disk sizes get higher performance. Thoughts?

https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disks-types