### PR TITLE
Move tomcat download url

### DIFF
--- a/opencga-app/app/scripts/docker/opencga-app/Dockerfile
+++ b/opencga-app/app/scripts/docker/opencga-app/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y wget tar \
   && apt-get clean
 
 # Download and install Tomcat
-RUN wget --quiet --no-cookies http://www-eu.apache.org/dist/tomcat/tomcat-8/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz -O /tmp/tomcat.tgz && \
+RUN wget --quiet --no-cookies https://archive.apache.org/dist/tomcat/tomcat-8/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz -O /tmp/tomcat.tgz && \
 tar xzvf /tmp/tomcat.tgz -C /opt && \
 mv /opt/apache-tomcat-${TOMCAT_VERSION} /opt/tomcat && \
 rm /tmp/tomcat.tgz && \


### PR DESCRIPTION
This fixes an issue where Tomcat versions are updated and the download link is no longer valid causing the docker build to fail. 