### PR TITLE
Fixed print_results for RestResponse in Python client

### DIFF
--- a/opencga-client/src/main/python/pyopencga/rest_response.py
+++ b/opencga-client/src/main/python/pyopencga/rest_response.py
@@ -108,7 +108,8 @@ class RestResponse:
             elif 'include' in self.params:
                 fields = self.params['include'].split(',')
             else:
-                fields = response['results'][0].keys()
+                if response['results']:
+                    fields = response['results'][0].keys()
 
             limit = limit if limit is not None else len(response['results'])
             if limit:


### PR DESCRIPTION
Addresses #1452

This PR includes the next changes:
- Fixed print_results for RestResponse when the query yields no results