### PR TITLE
temporarily disable checking ping time of mongo servers

### DIFF
--- a/opencga-catalog/src/main/java/org/opencb/opencga/catalog/db/mongodb/MongoDBAdaptorFactory.java
+++ b/opencga-catalog/src/main/java/org/opencb/opencga/catalog/db/mongodb/MongoDBAdaptorFactory.java
@@ -264,7 +264,7 @@ public class MongoDBAdaptorFactory implements DBAdaptorFactory {
 
         DatastoreStatus datastoreStatus = new DatastoreStatus();
         datastoreStatus.setStatus(DatastoreStatus.Status.UP);
-        datastoreStatus.setResponseTime(metaCollection.count(new Document()).getDbTime() + " ms");
+        //datastoreStatus.setResponseTime(metaCollection.count(new Document()).getDbTime() + " ms");
         statusList.add(datastoreStatus);
 
         return statusList;

--- a/opencga-catalog/src/main/java/org/opencb/opencga/catalog/db/mongodb/MongoDBAdaptorFactory.java
+++ b/opencga-catalog/src/main/java/org/opencb/opencga/catalog/db/mongodb/MongoDBAdaptorFactory.java
@@ -253,7 +253,7 @@ public class MongoDBAdaptorFactory implements DBAdaptorFactory {
                     ? DatastoreStatus.Status.UP : DatastoreStatus.Status.DOWN);
             // Per-machine response time is measured by doing ping to the machine. it's not possible to create a connection
             // to one single machine in the rep set
-            datastoreStatus.setResponseTime(getPingResponseTime(datastoreStatus.getHost()));
+            //datastoreStatus.setResponseTime(getPingResponseTime(datastoreStatus.getHost()));
             datastoreStatusList.add(datastoreStatus);
         }
         return datastoreStatusList;


### PR DESCRIPTION
In the GeL environment, `getPingResponseTime()` always returns NULL. This is fine but it also puts a really big stacktrace in the logs everytime `/health` or `/status` is called which is often.

For now, I've just commented out this check.

```
26-Apr-2021 15:27:17.935 INFO [http-nio-8080-exec-19] com.microsoft.graph.logger.DefaultLogger.logDebug Deserializing type GroupCollectionResponse
java.net.UnknownHostException: bio-uat-opencgainternal-mongodb-01:27017: invalid IPv6 address
        at java.net.InetAddress.getAllByName(InetAddress.java:1170)
        at java.net.InetAddress.getAllByName(InetAddress.java:1127)
        at java.net.InetAddress.getByName(InetAddress.java:1077)
        at org.opencb.opencga.catalog.db.mongodb.MongoDBAdaptorFactory.getPingResponseTime(MongoDBAdaptorFactory.java:277)
        at org.opencb.opencga.catalog.db.mongodb.MongoDBAdaptorFactory.getReplSetStatus(MongoDBAdaptorFactory.java:256)
        at org.opencb.opencga.catalog.db.mongodb.MongoDBAdaptorFactory.getDatabaseStatus(MongoDBAdaptorFactory.java:226)
        at org.opencb.opencga.catalog.managers.CatalogManager.healthCheck(CatalogManager.java:232)
        at org.opencb.opencga.server.rest.MetaWSServer.status(MetaWSServer.java:117)
        at sun.reflect.GeneratedMethodAccessor87.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory$1.invoke(ResourceMethodInvocationHandlerFactory.java:81)
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:144)
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:161)
        at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:160)
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:99)
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:389)
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:347)
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:102)
        at org.glassfish.jersey.server.ServerRuntime$2.run(ServerRuntime.java:326)
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:271)
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:267)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:267)
        at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:317)
        at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:305)
        at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:1154)
        at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:473)
        at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:427)
        at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:388)
        at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:341)
        at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:228)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
        at org.opencb.opencga.server.CORSFilter.doFilter(CORSFilter.java:46)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:199)
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)
        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:493)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:137)
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)
        at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:660)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)
        at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:798)
        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:808)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1498)
        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
        at datadog.trace.bootstrap.instrumentation.java.concurrent.Wrapper.run(Wrapper.java:25)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
        at java.lang.Thread.run(Thread.java:748)
java.net.UnknownHostException: bio-uat-opencgainternal-mongodb-03.gel.zone:27017: invalid IPv6 address
        at java.net.InetAddress.getAllByName(InetAddress.java:1170)
        ```