### PR TITLE
Release 1.3.18. upgrade log4j to 2.17

### DIFF
--- a/opencga-analysis/pom.xml
+++ b/opencga-analysis/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/opencga-app/pom.xml
+++ b/opencga-app/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-catalog/pom.xml
+++ b/opencga-catalog/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-client/pom.xml
+++ b/opencga-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-core/pom.xml
+++ b/opencga-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-server/pom.xml
+++ b/opencga-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-storage/opencga-storage-app/pom.xml
+++ b/opencga-storage/opencga-storage-app/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga-storage</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-storage/opencga-storage-benchmark/pom.xml
+++ b/opencga-storage/opencga-storage-benchmark/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>opencga-storage</artifactId>
         <groupId>org.opencb.opencga</groupId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/opencga-storage/opencga-storage-core/pom.xml
+++ b/opencga-storage/opencga-storage-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga-storage</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-storage/opencga-storage-hadoop/opencga-storage-hadoop-core/pom.xml
+++ b/opencga-storage/opencga-storage-hadoop/opencga-storage-hadoop-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga-storage-hadoop</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-storage/opencga-storage-hadoop/opencga-storage-hadoop-deps/pom.xml
+++ b/opencga-storage/opencga-storage-hadoop/opencga-storage-hadoop-deps/pom.xml
@@ -50,13 +50,13 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga-storage-hadoop</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <!--<relativePath>../pom.xml</relativePath>-->
     </parent>
 
     <!--<groupId>org.opencb.opencga</groupId>-->
     <artifactId>opencga-storage-hadoop-deps</artifactId>
-    <version>1.3.17</version>
+    <version>1.3.18</version>
 
     <properties>
         <checkstyle.skip>true</checkstyle.skip>

--- a/opencga-storage/opencga-storage-hadoop/pom.xml
+++ b/opencga-storage/opencga-storage-hadoop/pom.xml
@@ -26,12 +26,12 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga-storage</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>opencga-storage-hadoop</artifactId>
-    <version>1.3.17</version>
+    <version>1.3.18</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/opencga-storage/opencga-storage-mongodb/pom.xml
+++ b/opencga-storage/opencga-storage-mongodb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga-storage</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-storage/opencga-storage-server/pom.xml
+++ b/opencga-storage/opencga-storage-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga-storage</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-storage/pom.xml
+++ b/opencga-storage/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <groupId>org.opencb.opencga</groupId>
         <artifactId>opencga</artifactId>
-        <version>1.3.17</version>
+        <version>1.3.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <!-- Version must be set to a literal, variables cannot be used in nested modules -->
     <artifactId>opencga-storage</artifactId>
-    <version>1.3.17</version>
+    <version>1.3.18</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/opencga-test/pom.xml
+++ b/opencga-test/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.opencb.opencga</groupId>
     <artifactId>opencga-test</artifactId>
-    <version>1.3.17</version>
+    <version>1.3.18</version>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.opencb.opencga</groupId>
     <artifactId>opencga</artifactId>
-    <version>1.3.17</version>
+    <version>1.3.18</version>
     <packaging>pom</packaging>
     <name>OpenCGA</name>
     
@@ -37,7 +37,7 @@
     </modules>
 
     <properties>
-        <opencga.version>1.3.17</opencga.version>
+        <opencga.version>1.3.18</opencga.version>
         <java.version>1.8</java.version>
         <java-common-libs.version>3.6.0</java-common-libs.version>
         <biodata.version>1.3.3</biodata.version>
@@ -49,7 +49,7 @@
         <google.protobuf>3.1.0</google.protobuf>
         <google.grpc>1.0.1</google.grpc>
         <slf4j.version>1.7.25</slf4j.version>
-        <log4j2.version>2.13.3</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
         <junit.version>4.12</junit.version>
         <solr.version>6.4.1</solr.version>
 


### PR DESCRIPTION
https://logging.apache.org/log4j/2.x/
Upgrade log4j library to latest version - v2.17.1