### PR TITLE
reverse change in version microsoft-graph: restore prior version (1.4.0)

### DIFF
--- a/opencga-catalog/pom.xml
+++ b/opencga-catalog/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.microsoft.graph</groupId>
             <artifactId>microsoft-graph</artifactId>
-            <version>1.6.0</version>
+            <version>1.4.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
reverse change in version microsoft-graph: restore prior version (1.4.0)

Reason: In despite of successful login authentication query, there were exception errors and also observed that logger JSON output stopped streaming to stdout/stderr

com.microsoft.aad.adal4j.AuthenticationException: {"error":"invalid_grant","error_uri":"https:\/\/login.microsoftonline.com\/error?code=9002313"}