### PR TITLE
TASK-2337 - Interpretation locking inconsistency issue: a locked secondary interpretation can not be promoted to primary, but a locked primary can be demoted to secondary

### DIFF
--- a/opencga-catalog/src/main/java/org/opencb/opencga/catalog/managers/InterpretationManager.java
+++ b/opencga-catalog/src/main/java/org/opencb/opencga/catalog/managers/InterpretationManager.java
@@ -910,7 +910,8 @@ public class InterpretationManager extends ResourceManager<Interpretation> {
             }
         }
 
-        if (interpretation.isLocked() && parameters.getBoolean(InterpretationDBAdaptor.QueryParams.LOCKED.key(), true)) {
+        if (!parameters.isEmpty() && interpretation.isLocked()
+                && parameters.getBoolean(InterpretationDBAdaptor.QueryParams.LOCKED.key(), true)) {
             throw new CatalogException("Could not update the Interpretation. Interpretation '" + interpretation.getId()
                     + " is locked. Please, unlock it first.");
         }


### PR DESCRIPTION
TASK-2337