### PR TITLE
TASK-2588 - NullPointerExceptions when LDAP is set not to use the serviceAccount user credential (authUserId, authPassword)

### DIFF
--- a/opencga-catalog/src/main/java/org/opencb/opencga/catalog/auth/authentication/LDAPAuthenticationManager.java
+++ b/opencga-catalog/src/main/java/org/opencb/opencga/catalog/auth/authentication/LDAPAuthenticationManager.java
@@ -486,14 +486,18 @@ public class LDAPAuthenticationManager extends AuthenticationManager {
     }
 
     protected static String envToStringRedacted(Hashtable<String, Object> env) {
-        // Replace credentials only if exists
-        Object remove = env.replace(DirContext.SECURITY_CREDENTIALS, "*********");
+        String string;
+        if (env.containsKey(DirContext.SECURITY_CREDENTIALS)) {
+            // Replace credentials only if exists
+            Object remove = env.replace(DirContext.SECURITY_CREDENTIALS, "*********");
 
-        String string = env.toString();
+            string = env.toString();
 
-        // Restore credentials, if any
-        env.replace(DirContext.SECURITY_CREDENTIALS, remove);
-
+            // Restore credentials, if any
+            env.replace(DirContext.SECURITY_CREDENTIALS, remove);
+        } else {
+            string = env.toString();
+        }
         return string;
     }
 


### PR DESCRIPTION
TASK-2588