### PR TITLE
TASK-5394 - NoClassDefFoundError: org/apache/logging/log4j/spi/AbstractLoggerAdapter

### DIFF
--- a/opencga-storage/opencga-storage-hadoop/opencga-storage-hadoop-core/pom.xml
+++ b/opencga-storage/opencga-storage-hadoop/opencga-storage-hadoop-core/pom.xml
@@ -142,12 +142,10 @@
         <dependency>
             <groupId>org.opencb.cellbase</groupId>
             <artifactId>cellbase-client</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>
@@ -164,7 +162,6 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.opencb.commons</groupId>
@@ -224,7 +221,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -300,6 +296,12 @@
                                             *
                                         </ignoredUnusedDeclaredDependency>
                                     </ignoredUnusedDeclaredDependencies>
+                                    <ignoredNonTestScopedDependencies>
+                                        <ignoredNonTestScopedDependency>org.apache.logging.log4j:log4j-api</ignoredNonTestScopedDependency>
+                                        <ignoredNonTestScopedDependency>org.apache.logging.log4j:log4j-core</ignoredNonTestScopedDependency>
+                                        <ignoredNonTestScopedDependency>org.opencb.cellbase:cellbase-client</ignoredNonTestScopedDependency>
+                                        <ignoredNonTestScopedDependency>org.apache.zookeeper:zookeeper</ignoredNonTestScopedDependency>
+                                    </ignoredNonTestScopedDependencies>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
TASK-5394 - NoClassDefFoundError: org/apache/logging/log4j/spi/AbstractLoggerAdapter