### PR TITLE
TASK-5475 - The version of Java (11.0.21) used to run our analysis is deprecated, and SonarCloud no longer supports it.

### DIFF
--- a/.github/workflows/scripts/get_same_branch.sh
+++ b/.github/workflows/scripts/get_same_branch.sh
@@ -7,10 +7,6 @@ if [[ -z $BRANCH_NAME  ]]; then
   exit 1
 fi
 
-if [[ $BRANCH_NAME != "TASK-"* ]]; then
-  echo "No need to check dependencies."
-  exit 0
-fi
 
 function install(){
   local REPO=$1

--- a/.github/workflows/scripts/get_same_branch.sh
+++ b/.github/workflows/scripts/get_same_branch.sh
@@ -7,7 +7,7 @@ if [[ -z $BRANCH_NAME  ]]; then
   exit 1
 fi
 
-if [[ $BRANCH_NAME != "TASK-"*   ]]; then
+if [[ $BRANCH_NAME != "TASK-"* ]]; then
   echo "No need to check dependencies."
   exit 0
 fi

--- a/.github/workflows/test-analysis.yml
+++ b/.github/workflows/test-analysis.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
       - name: Install dependencies branches
         run: |

--- a/opencga-server/pom.xml
+++ b/opencga-server/pom.xml
@@ -252,7 +252,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
                 <configuration>
                     <warName>${opencga.war.name}</warName>
                     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -146,12 +146,8 @@
         <servlet-api.version>2.5-20081211</servlet-api.version>
 
         <kryo.version>2.23.0</kryo.version>
-        <!--TO REMOVE:
-        The version of Java (11.0.21) used to run this analysis is deprecated, and SonarCloud no longer supports it. Please upgrade to Java 17 or later.
-        As a temporary measure, you can set the property 'sonar.scanner.force-deprecated-java-version' to 'true' to continue using Java 11.0.21
-        This workaround will only be effective until January 28, 2024. After this date, all scans using the deprecated Java 11 will fail.
-        -->
-        <sonar.scanner.force-deprecated-java-version>true</sonar.scanner.force-deprecated-java-version>
+        <lombok.version>1.18.30</lombok.version>
+        <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
     </properties>
 
     <scm>
@@ -994,6 +990,12 @@
                 <version>${grep4j.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.redisson</groupId>
                 <artifactId>redisson</artifactId>
                 <version>${redisson.version}</version>
@@ -1093,6 +1095,7 @@
                 <artifactId>kryo</artifactId>
                 <version>${kryo.version}</version>
             </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -1116,6 +1119,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-report-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>${maven-war-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
TASK-5475 - The version of Java (11.0.21) used to run our analysis is deprecated, and SonarCloud no longer supports it.