### PR TITLE
TASK-6256 - Main OpenCGA v3.0.0 migration loses track of previous migration executions

### DIFF
--- a/opencga-app/src/main/java/org/opencb/opencga/app/cli/admin/executors/MigrationCommandExecutor.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/cli/admin/executors/MigrationCommandExecutor.java
@@ -6,7 +6,7 @@ import org.opencb.commons.datastore.core.Event;
 import org.opencb.commons.datastore.core.ObjectMap;
 import org.opencb.opencga.app.cli.admin.options.MigrationCommandOptions;
 import org.opencb.opencga.app.cli.main.io.Table;
-import org.opencb.opencga.app.migrations.v3_0_0.OrganizationMigration;
+import org.opencb.opencga.app.migrations.v3.v3_0_0.OrganizationMigration;
 import org.opencb.opencga.catalog.exceptions.CatalogException;
 import org.opencb.opencga.catalog.managers.CatalogManager;
 import org.opencb.opencga.catalog.migration.Migration;

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_0_3/catalog/java/Migration1.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_0_3/catalog/java/Migration1.java
@@ -5,7 +5,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 import org.opencb.opencga.catalog.migration.MigrationTool;
 
 @Migration(id = "recalculate_roles", description = "Recalculate roles from Family #1763", version = "2.0.3", date = 20210528,
-    deprecatedSince = "v3.0.0")
+    deprecatedSince = "3.0.0")
 public class Migration1 extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_0_3/catalog/java/Migration1.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_0_3/catalog/java/Migration1.java
@@ -1,0 +1,14 @@
+package org.opencb.opencga.app.migrations.v2.v2_0_3.catalog.java;
+
+import org.opencb.opencga.catalog.exceptions.CatalogException;
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "recalculate_roles", description = "Recalculate roles from Family #1763", version = "2.0.3", date = 20210528,
+    deprecatedSince = "v3.0.0")
+public class Migration1 extends MigrationTool {
+
+    @Override
+    protected void run() throws CatalogException {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_0_5/catalog/java/initialiseGroups.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_0_5/catalog/java/initialiseGroups.java
@@ -1,0 +1,15 @@
+package org.opencb.opencga.app.migrations.v2.v2_0_5.catalog.java;
+
+
+import org.opencb.opencga.catalog.exceptions.CatalogException;
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "initialise_groups", description = "Initialise userIds list from groups #1791", version = "2.0.5", date = 20210621,
+        deprecatedSince = "v3.0.0")
+public class initialiseGroups extends MigrationTool {
+
+    @Override
+    protected void run() throws CatalogException {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_0_5/catalog/java/initialiseGroups.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_0_5/catalog/java/initialiseGroups.java
@@ -6,7 +6,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 import org.opencb.opencga.catalog.migration.MigrationTool;
 
 @Migration(id = "initialise_groups", description = "Initialise userIds list from groups #1791", version = "2.0.5", date = 20210621,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class initialiseGroups extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_0_6/catalog/removeDeletedFileReferencesFromSample.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_0_6/catalog/removeDeletedFileReferencesFromSample.java
@@ -6,7 +6,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 import org.opencb.opencga.catalog.migration.MigrationTool;
 
 @Migration(id = "remove_file_references_from_sample", description = "Remove deleted file references from samples #1815", version = "2.0.6",
-        date = 20210901, deprecatedSince = "v3.0.0")
+        date = 20210901, deprecatedSince = "3.0.0")
 public class removeDeletedFileReferencesFromSample extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_0_6/catalog/removeDeletedFileReferencesFromSample.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_0_6/catalog/removeDeletedFileReferencesFromSample.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_0_6.catalog;
+
+
+import org.opencb.opencga.catalog.exceptions.CatalogException;
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "remove_file_references_from_sample", description = "Remove deleted file references from samples #1815", version = "2.0.6",
+        date = 20210901, deprecatedSince = "v3.0.0")
+public class removeDeletedFileReferencesFromSample extends MigrationTool {
+
+    @Override
+    protected void run() throws CatalogException {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_12_0/catalog/AddAnnotationSetsInClinicalAnalysisMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_12_0/catalog/AddAnnotationSetsInClinicalAnalysisMigration.java
@@ -10,7 +10,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         language = Migration.MigrationLanguage.JAVA,
         date = 20231116,
-        deprecatedSince = "v3.0.0"
+        deprecatedSince = "3.0.0"
 )
 public class AddAnnotationSetsInClinicalAnalysisMigration extends MigrationTool {
 

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_12_0/catalog/AddAnnotationSetsInClinicalAnalysisMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_12_0/catalog/AddAnnotationSetsInClinicalAnalysisMigration.java
@@ -1,0 +1,20 @@
+package org.opencb.opencga.app.migrations.v2.v2_12_0.catalog;
+
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_annotation_sets_to_clinical_analysis" ,
+        description = "Add private annotation fields to ClinicalAnalysis documents #TASK-5198",
+        version = "2.12.0",
+        domain = Migration.MigrationDomain.CATALOG,
+        language = Migration.MigrationLanguage.JAVA,
+        date = 20231116,
+        deprecatedSince = "v3.0.0"
+)
+public class AddAnnotationSetsInClinicalAnalysisMigration extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_12_0/catalog/CompleteClinicalReportDataModelMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_12_0/catalog/CompleteClinicalReportDataModelMigration.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         language = Migration.MigrationLanguage.JAVA,
         date = 20231128,
-        deprecatedSince = "v3.0.0"
+        deprecatedSince = "3.0.0"
 )
 public class CompleteClinicalReportDataModelMigration extends MigrationTool {
 

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_12_0/catalog/CompleteClinicalReportDataModelMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_12_0/catalog/CompleteClinicalReportDataModelMigration.java
@@ -1,0 +1,19 @@
+package org.opencb.opencga.app.migrations.v2.v2_12_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_clinical_report_data_model" ,
+        description = "Complete Clinical Report data model #TASK-5198",
+        version = "2.12.0",
+        domain = Migration.MigrationDomain.CATALOG,
+        language = Migration.MigrationLanguage.JAVA,
+        date = 20231128,
+        deprecatedSince = "v3.0.0"
+)
+public class CompleteClinicalReportDataModelMigration extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/AddMissingIndexes.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/AddMissingIndexes.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         patch = 1,
         date = 20210928,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class AddMissingIndexes extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/AddMissingIndexes.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/AddMissingIndexes.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.catalog.java;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_missing_indexes",
+        description = "Add missing indexes", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        patch = 1,
+        date = 20210928,
+        deprecatedSince = "v3.0.0")
+public class AddMissingIndexes extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/AddPanelsToInterpretations.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/AddPanelsToInterpretations.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20210713,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class AddPanelsToInterpretations extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/AddPanelsToInterpretations.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/AddPanelsToInterpretations.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.catalog.java;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_panels_to_interpretations",
+        description = "Add panels to Interpretations #1802", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20210713,
+        deprecatedSince = "v3.0.0")
+public class AddPanelsToInterpretations extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/CreateAuditIndexes.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/CreateAuditIndexes.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         patch = 1,
         date = 20210622,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class CreateAuditIndexes extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/CreateAuditIndexes.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/CreateAuditIndexes.java
@@ -1,0 +1,19 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.catalog.java;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "create_audit_indexes", description = "Create Audit indexes", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        patch = 1,
+        date = 20210622,
+        deprecatedSince = "v3.0.0")
+public class CreateAuditIndexes extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}
+

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/PanelLock.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/PanelLock.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.catalog.java;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_panel_lock",
+        description = "Add new panelLock to ClinicalAnalysis #1802", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        patch = 1,
+        date = 20210713,
+        deprecatedSince = "v3.0.0")
+public class PanelLock extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/PanelLock.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/PanelLock.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         patch = 1,
         date = 20210713,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class PanelLock extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/RemoveRCVersionsFromMigrationRuns.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/RemoveRCVersionsFromMigrationRuns.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.catalog.java;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "remove_rc_version_from_migration_runs",
+        description = "Remove RC versions from migration runs stored in catalog", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        patch = 1,
+        date = 20210723,
+        deprecatedSince = "v3.0.0")
+public class RemoveRCVersionsFromMigrationRuns extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/RemoveRCVersionsFromMigrationRuns.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/RemoveRCVersionsFromMigrationRuns.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         patch = 1,
         date = 20210723,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class RemoveRCVersionsFromMigrationRuns extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/RenameDatastoreConfigurationToOptions.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/RenameDatastoreConfigurationToOptions.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.catalog.java;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "rename_datastore_configuration_to_options", description = "Rename project.internal.datastores.variant.configuration to options", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        patch = 1,
+        date = 20210617,
+        deprecatedSince = "v3.0.0")
+public class RenameDatastoreConfigurationToOptions extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/RenameDatastoreConfigurationToOptions.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/RenameDatastoreConfigurationToOptions.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         patch = 1,
         date = 20210617,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class RenameDatastoreConfigurationToOptions extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/StudyClinicalConfigurationRelocation.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/StudyClinicalConfigurationRelocation.java
@@ -1,0 +1,19 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.catalog.java;
+
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "move_study_clinical_config_to_internal",
+        description = "Move Study ClinicalConfiguration to internal.configuration", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        patch = 1,
+        date = 20210708,
+        deprecatedSince = "v3.0.0")
+public class StudyClinicalConfigurationRelocation extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/StudyClinicalConfigurationRelocation.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/StudyClinicalConfigurationRelocation.java
@@ -10,7 +10,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         patch = 1,
         date = 20210708,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class StudyClinicalConfigurationRelocation extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/VariantFileStatsRelocation.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/VariantFileStatsRelocation.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.catalog.java;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "move_variant_file_stats_to_qc", description = "Move opencga_file_variant_stats annotation set from variable sets to " +
+        "FileQualityControl", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.STORAGE,
+        patch = 1,
+        date = 20210614,
+        deprecatedSince = "v3.0.0")
+public class VariantFileStatsRelocation extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/VariantFileStatsRelocation.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/java/VariantFileStatsRelocation.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.STORAGE,
         patch = 1,
         date = 20210614,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class VariantFileStatsRelocation extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration1.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration1.java
@@ -1,0 +1,14 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.catalog.javascript;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationException;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "build_rga_indexes", description = "Create index for sample RGA status #1693", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVASCRIPT, date = 20210528, deprecatedSince = "v3.0.0")
+public class Migration1 extends MigrationTool {
+
+    @Override
+    protected void run() throws MigrationException {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration1.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration1.java
@@ -5,7 +5,7 @@ import org.opencb.opencga.catalog.migration.MigrationException;
 import org.opencb.opencga.catalog.migration.MigrationTool;
 
 @Migration(id = "build_rga_indexes", description = "Create index for sample RGA status #1693", version = "2.1.0",
-        language = Migration.MigrationLanguage.JAVASCRIPT, date = 20210528, deprecatedSince = "v3.0.0")
+        language = Migration.MigrationLanguage.JAVASCRIPT, date = 20210528, deprecatedSince = "3.0.0")
 public class Migration1 extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration2.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration2.java
@@ -5,7 +5,7 @@ import org.opencb.opencga.catalog.migration.MigrationException;
 import org.opencb.opencga.catalog.migration.MigrationTool;
 
 @Migration(id = "init_userId_group_arrays", description = "Initialise all userIds arrays from groups #1735", version = "2.1.0",
-        language = Migration.MigrationLanguage.JAVASCRIPT, date = 20210528, deprecatedSince = "v3.0.0")
+        language = Migration.MigrationLanguage.JAVASCRIPT, date = 20210528, deprecatedSince = "3.0.0")
 public class Migration2 extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration2.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration2.java
@@ -1,0 +1,14 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.catalog.javascript;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationException;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "init_userId_group_arrays", description = "Initialise all userIds arrays from groups #1735", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVASCRIPT, date = 20210528, deprecatedSince = "v3.0.0")
+public class Migration2 extends MigrationTool {
+
+    @Override
+    protected void run() throws MigrationException {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration3.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration3.java
@@ -1,0 +1,14 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.catalog.javascript;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationException;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "init_ca_panel_arrays", description = "Initialise panels array in Clinical Analysis #1759", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVASCRIPT, date = 20210528, deprecatedSince = "v3.0.0")
+public class Migration3 extends MigrationTool {
+
+    @Override
+    protected void run() throws MigrationException {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration3.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration3.java
@@ -5,7 +5,7 @@ import org.opencb.opencga.catalog.migration.MigrationException;
 import org.opencb.opencga.catalog.migration.MigrationTool;
 
 @Migration(id = "init_ca_panel_arrays", description = "Initialise panels array in Clinical Analysis #1759", version = "2.1.0",
-        language = Migration.MigrationLanguage.JAVASCRIPT, date = 20210528, deprecatedSince = "v3.0.0")
+        language = Migration.MigrationLanguage.JAVASCRIPT, date = 20210528, deprecatedSince = "3.0.0")
 public class Migration3 extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration4.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration4.java
@@ -1,0 +1,14 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.catalog.javascript;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationException;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "update_qc_file_sample_fields", description = "Update QC fields from Sample and File #1730", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVASCRIPT, date = 20210531, patch = 4, deprecatedSince = "v3.0.0")
+public class Migration4 extends MigrationTool {
+
+    @Override
+    protected void run() throws MigrationException {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration4.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/catalog/javascript/Migration4.java
@@ -5,7 +5,7 @@ import org.opencb.opencga.catalog.migration.MigrationException;
 import org.opencb.opencga.catalog.migration.MigrationTool;
 
 @Migration(id = "update_qc_file_sample_fields", description = "Update QC fields from Sample and File #1730", version = "2.1.0",
-        language = Migration.MigrationLanguage.JAVASCRIPT, date = 20210531, patch = 4, deprecatedSince = "v3.0.0")
+        language = Migration.MigrationLanguage.JAVASCRIPT, date = 20210531, patch = 4, deprecatedSince = "3.0.0")
 public class Migration4 extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/storage/AddCellbaseConfigurationToProject.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/storage/AddCellbaseConfigurationToProject.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.storage;
+
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_cellbase_configuration_to_project", description = "Add cellbase configuration from storage-configuration.yml to project.internal.cellbase", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.STORAGE,
+        patch = 3,
+        date = 20210616,
+        deprecatedSince = "v3.0.0")
+public class AddCellbaseConfigurationToProject extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/storage/AddCellbaseConfigurationToProject.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/storage/AddCellbaseConfigurationToProject.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.STORAGE,
         patch = 3,
         date = 20210616,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class AddCellbaseConfigurationToProject extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/storage/DefaultSampleIndexConfiguration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/storage/DefaultSampleIndexConfiguration.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.Migration;
         domain = Migration.MigrationDomain.STORAGE,
         patch = 7,
         date = 20210721,
-        deprecatedSince = "v3.0.0") // Needs to run after StudyClinicalConfigurationRelocation
+        deprecatedSince = "3.0.0") // Needs to run after StudyClinicalConfigurationRelocation
 public class DefaultSampleIndexConfiguration extends StorageMigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/storage/DefaultSampleIndexConfiguration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/storage/DefaultSampleIndexConfiguration.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.storage;
+
+
+import org.opencb.opencga.app.migrations.StorageMigrationTool;
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "default_sample_index_configuration", description = "Add a default backward compatible sample index configuration", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.STORAGE,
+        patch = 7,
+        date = 20210721,
+        deprecatedSince = "v3.0.0") // Needs to run after StudyClinicalConfigurationRelocation
+public class DefaultSampleIndexConfiguration extends StorageMigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/storage/NewClinicalSignificanceFields.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/storage/NewClinicalSignificanceFields.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_1_0.storage;
+
+import org.opencb.opencga.app.migrations.StorageMigrationTool;
+import org.opencb.opencga.catalog.migration.Migration;
+
+
+@Migration(id = "new_clinical_significance_fields", description = "Add new clinical significance fields and combinations for variant storage and solr", version = "2.1.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.STORAGE,
+        patch = 1,
+        date = 20210708,
+        deprecatedSince = "v3.0.0")
+public class NewClinicalSignificanceFields extends StorageMigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/storage/NewClinicalSignificanceFields.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_1_0/storage/NewClinicalSignificanceFields.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.Migration;
         domain = Migration.MigrationDomain.STORAGE,
         patch = 1,
         date = 20210708,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class NewClinicalSignificanceFields extends StorageMigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddMissingClinicalAudit.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddMissingClinicalAudit.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Add missing CREATE_INTERPRETATION audits in ClinicalAnalysis", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211227, deprecatedSince = "v3.0.0")
+        date = 20211227, deprecatedSince = "3.0.0")
 public class AddMissingClinicalAudit extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddMissingClinicalAudit.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddMissingClinicalAudit.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_missing_create_interpretation_in_clinical_audit",
+        description = "Add missing CREATE_INTERPRETATION audits in ClinicalAnalysis", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211227, deprecatedSince = "v3.0.0")
+public class AddMissingClinicalAudit extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddNameFieldInCohort.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddNameFieldInCohort.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Add new name field to Cohort #1902", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20220228, deprecatedSince = "v3.0.0")
+        date = 20220228, deprecatedSince = "3.0.0")
 public class AddNameFieldInCohort extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddNameFieldInCohort.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddNameFieldInCohort.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_name_field_in_cohort_1902",
+        description = "Add new name field to Cohort #1902", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220228, deprecatedSince = "v3.0.0")
+public class AddNameFieldInCohort extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddNewAllowedBiotype.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddNewAllowedBiotype.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         patch = 2,
-        date = 20211209, deprecatedSince = "v3.0.0")
+        date = 20211209, deprecatedSince = "3.0.0")
 public class AddNewAllowedBiotype extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddNewAllowedBiotype.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddNewAllowedBiotype.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_new_allowed_biotype",
+        description = "Add new allowed biotype 'guide_RNA', #1856", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        patch = 2,
+        date = 20211209, deprecatedSince = "v3.0.0")
+public class AddNewAllowedBiotype extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddNewFileInternalIndex_1850.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddNewFileInternalIndex_1850.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Add new FileInternalVariant and FileInternalAlignment index #1850", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211127, deprecatedSince = "v3.0.0")
+        date = 20211127, deprecatedSince = "3.0.0")
 public class AddNewFileInternalIndex_1850 extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddNewFileInternalIndex_1850.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddNewFileInternalIndex_1850.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "new_file_internal_index_1850",
+        description = "Add new FileInternalVariant and FileInternalAlignment index #1850", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211127, deprecatedSince = "v3.0.0")
+public class AddNewFileInternalIndex_1850 extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddSampleInternalVariant_1851.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddSampleInternalVariant_1851.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_sample_internal_variant_1851",
+        description = "Add new SampleInternalVariant #1851", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211129, deprecatedSince = "v3.0.0")
+public class AddSampleInternalVariant_1851 extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddSampleInternalVariant_1851.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/AddSampleInternalVariant_1851.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Add new SampleInternalVariant #1851", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211129, deprecatedSince = "v3.0.0")
+        date = 20211129, deprecatedSince = "3.0.0")
 public class AddSampleInternalVariant_1851 extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ChangeInterpretationMethods.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ChangeInterpretationMethods.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Remove list of methods from Interpretations #1841", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211112, deprecatedSince = "v3.0.0")
+        date = 20211112, deprecatedSince = "3.0.0")
 public class ChangeInterpretationMethods extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ChangeInterpretationMethods.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ChangeInterpretationMethods.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "change_interpretation_method",
+        description = "Remove list of methods from Interpretations #1841", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211112, deprecatedSince = "v3.0.0")
+public class ChangeInterpretationMethods extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ClinicalVariantEvidenceMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ClinicalVariantEvidenceMigration.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_clinical_variant_evidence_review",
+        description = "Add new ClinicalVariantEvidenceReview object, #1874", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220112, deprecatedSince = "v3.0.0")
+public class ClinicalVariantEvidenceMigration extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ClinicalVariantEvidenceMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ClinicalVariantEvidenceMigration.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Add new ClinicalVariantEvidenceReview object, #1874", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20220112, deprecatedSince = "v3.0.0")
+        date = 20220112, deprecatedSince = "3.0.0")
 public class ClinicalVariantEvidenceMigration extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/DeleteUnusedVariableSets.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/DeleteUnusedVariableSets.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "delete_unused_variablesets",
+        description = "Delete unused VariableSets, #1859", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        patch = 2,
+        date = 20211210, deprecatedSince = "v3.0.0")
+public class DeleteUnusedVariableSets extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/DeleteUnusedVariableSets.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/DeleteUnusedVariableSets.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         patch = 2,
-        date = 20211210, deprecatedSince = "v3.0.0")
+        date = 20211210, deprecatedSince = "3.0.0")
 public class DeleteUnusedVariableSets extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/FixFamilyReferences.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/FixFamilyReferences.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Fix Family references, #TASK-489", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20220324, deprecatedSince = "v3.0.0")
+        date = 20220324, deprecatedSince = "3.0.0")
 public class FixFamilyReferences extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/FixFamilyReferences.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/FixFamilyReferences.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "fix_family_references_in_individual",
+        description = "Fix Family references, #TASK-489", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220324, deprecatedSince = "v3.0.0")
+public class FixFamilyReferences extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/FixNonExistingMoIFromPanels.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/FixNonExistingMoIFromPanels.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         patch = 2,
-        date = 20220111, deprecatedSince = "v3.0.0")
+        date = 20220111, deprecatedSince = "3.0.0")
 public class FixNonExistingMoIFromPanels extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/FixNonExistingMoIFromPanels.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/FixNonExistingMoIFromPanels.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "fix_non_existing_mois_from_panels",
+        description = "Remove non-existing MOIs from Panels", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        patch = 2,
+        date = 20220111, deprecatedSince = "v3.0.0")
+public class FixNonExistingMoIFromPanels extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveClinicalAnalysisQualityControl.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveClinicalAnalysisQualityControl.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Quality control normalize comments and fields #1826", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211001, deprecatedSince = "v3.0.0")
+        date = 20211001, deprecatedSince = "3.0.0")
 public class ImproveClinicalAnalysisQualityControl extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveClinicalAnalysisQualityControl.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveClinicalAnalysisQualityControl.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "improve_ca_quality_control",
+        description = "Quality control normalize comments and fields #1826", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211001, deprecatedSince = "v3.0.0")
+public class ImproveClinicalAnalysisQualityControl extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveFileQualityControl.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveFileQualityControl.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "improve_file_quality_control",
+        description = "Quality control normalize comments and fields #1826", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211001, deprecatedSince = "v3.0.0")
+public class ImproveFileQualityControl extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveFileQualityControl.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveFileQualityControl.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Quality control normalize comments and fields #1826", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211001, deprecatedSince = "v3.0.0")
+        date = 20211001, deprecatedSince = "3.0.0")
 public class ImproveFileQualityControl extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveIndividualQualityControl.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveIndividualQualityControl.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "improve_individual_quality_control",
+        description = "Quality control normalize comments and fields #1826", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211001, deprecatedSince = "v3.0.0")
+public class ImproveIndividualQualityControl extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveIndividualQualityControl.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveIndividualQualityControl.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Quality control normalize comments and fields #1826", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211001, deprecatedSince = "v3.0.0")
+        date = 20211001, deprecatedSince = "3.0.0")
 public class ImproveIndividualQualityControl extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveVariableSetNamesAndDescriptions.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/ImproveVariableSetNamesAndDescriptions.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "improveVariableSetNamesAndDescriptions",
+        description = "Improve VariableSet names and descriptions", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211210)
+public class ImproveVariableSetNamesAndDescriptions extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RemoveFileDocsFromCA.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RemoveFileDocsFromCA.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Store references of File in Clinical Analysis and not full File documents #1837", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211102, deprecatedSince = "v3.0.0")
+        date = 20211102, deprecatedSince = "3.0.0")
 public class RemoveFileDocsFromCA extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RemoveFileDocsFromCA.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RemoveFileDocsFromCA.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "remove_file_docs_from_clinical_analyses",
+        description = "Store references of File in Clinical Analysis and not full File documents #1837", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211102, deprecatedSince = "v3.0.0")
+public class RemoveFileDocsFromCA extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RemoveParallelIndexes.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RemoveParallelIndexes.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "remove_parallel_indexes",
+        description = "Remove parallel array indexes #CU-20jc4tx", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220310, deprecatedSince = "v3.0.0")
+public class RemoveParallelIndexes extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RemoveParallelIndexes.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RemoveParallelIndexes.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Remove parallel array indexes #CU-20jc4tx", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20220310, deprecatedSince = "v3.0.0")
+        date = 20220310, deprecatedSince = "3.0.0")
 public class RemoveParallelIndexes extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameFamilyQualityControlFields.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameFamilyQualityControlFields.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Rename FamilyQualityControl fields #1844", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211119, deprecatedSince = "v3.0.0")
+        date = 20211119, deprecatedSince = "3.0.0")
 public class RenameFamilyQualityControlFields extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameFamilyQualityControlFields.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameFamilyQualityControlFields.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "rename_family_quality_control_fields",
+        description = "Rename FamilyQualityControl fields #1844", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211119, deprecatedSince = "v3.0.0")
+public class RenameFamilyQualityControlFields extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameFileQualityControlFields.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameFileQualityControlFields.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "rename_file_quality_control_fields",
+        description = "Rename FileQualityControl fields #1844", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211119, deprecatedSince = "v3.0.0")
+public class RenameFileQualityControlFields extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameFileQualityControlFields.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameFileQualityControlFields.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Rename FileQualityControl fields #1844", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211119, deprecatedSince = "v3.0.0")
+        date = 20211119, deprecatedSince = "3.0.0")
 public class RenameFileQualityControlFields extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameIndividualQualityControlFields.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameIndividualQualityControlFields.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "rename_individual_quality_control_fields",
+        description = "Rename IndividualQualityControl fields #1844", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211119, deprecatedSince = "v3.0.0")
+public class RenameIndividualQualityControlFields extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameIndividualQualityControlFields.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameIndividualQualityControlFields.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Rename IndividualQualityControl fields #1844", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211119, deprecatedSince = "v3.0.0")
+        date = 20211119, deprecatedSince = "3.0.0")
 public class RenameIndividualQualityControlFields extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameInterpretationFindingStats.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameInterpretationFindingStats.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "rename_interpretation_stats_field",
+        description = "Rename interpretation stats field #1819", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211115, deprecatedSince = "v3.0.0")
+public class RenameInterpretationFindingStats extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameInterpretationFindingStats.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameInterpretationFindingStats.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Rename interpretation stats field #1819", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211115, deprecatedSince = "v3.0.0")
+        date = 20211115, deprecatedSince = "3.0.0")
 public class RenameInterpretationFindingStats extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameSampleQualityControlFields.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameSampleQualityControlFields.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "rename_sample_quality_control_fields",
+        description = "Rename SampleQualityControl fields #1844", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        patch = 2,
+        date = 20211119, deprecatedSince = "v3.0.0")
+public class RenameSampleQualityControlFields extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameSampleQualityControlFields.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/RenameSampleQualityControlFields.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         patch = 2,
-        date = 20211119, deprecatedSince = "v3.0.0")
+        date = 20211119, deprecatedSince = "3.0.0")
 public class RenameSampleQualityControlFields extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addDefaultVariantCallerInterpretationStudyConfiguration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addDefaultVariantCallerInterpretationStudyConfiguration.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_variant_caller_interpretation_configuration",
+        description = "Add default variant caller Interpretation Study configuration #1822", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20210916, deprecatedSince = "v3.0.0")
+public class addDefaultVariantCallerInterpretationStudyConfiguration extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addDefaultVariantCallerInterpretationStudyConfiguration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addDefaultVariantCallerInterpretationStudyConfiguration.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Add default variant caller Interpretation Study configuration #1822", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20210916, deprecatedSince = "v3.0.0")
+        date = 20210916, deprecatedSince = "3.0.0")
 public class addDefaultVariantCallerInterpretationStudyConfiguration extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddInternalLastModified.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddInternalLastModified.java
@@ -1,0 +1,10 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addInternalLastModified;
+
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+public abstract class AddInternalLastModified extends MigrationTool {
+
+    protected void addInternalModificationDate(String collection) {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToClinicalInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToClinicalInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_modificationDate_to_clinical.internal", description = "Add internal modificationDate to Clinical #1810",
         version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210812, deprecatedSince = "v3.0.0")
+        date = 20210812, deprecatedSince = "3.0.0")
 public class AddModificationDateToClinicalInternal extends AddInternalLastModified {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToClinicalInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToClinicalInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addInternalLastModified;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_modificationDate_to_clinical.internal", description = "Add internal modificationDate to Clinical #1810",
+        version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210812, deprecatedSince = "v3.0.0")
+public class AddModificationDateToClinicalInternal extends AddInternalLastModified {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToCohortInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToCohortInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addInternalLastModified;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_modificationDate_to_cohort.internal", description = "Add internal modificationDate to Cohort #1810",
+        version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210812, deprecatedSince = "v3.0.0")
+public class AddModificationDateToCohortInternal extends AddInternalLastModified {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToCohortInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToCohortInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_modificationDate_to_cohort.internal", description = "Add internal modificationDate to Cohort #1810",
         version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210812, deprecatedSince = "v3.0.0")
+        date = 20210812, deprecatedSince = "3.0.0")
 public class AddModificationDateToCohortInternal extends AddInternalLastModified {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToFamilyInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToFamilyInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addInternalLastModified;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_modificationDate_to_family.internal", description = "Add internal modificationDate to Family #1810",
+        version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210812, deprecatedSince = "v3.0.0")
+public class AddModificationDateToFamilyInternal extends AddInternalLastModified {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToFamilyInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToFamilyInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_modificationDate_to_family.internal", description = "Add internal modificationDate to Family #1810",
         version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210812, deprecatedSince = "v3.0.0")
+        date = 20210812, deprecatedSince = "3.0.0")
 public class AddModificationDateToFamilyInternal extends AddInternalLastModified {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToFileInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToFileInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_modificationDate_to_file.internal", description = "Add internal modificationDate to File #1810",
         version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210812, deprecatedSince = "v3.0.0")
+        date = 20210812, deprecatedSince = "3.0.0")
 public class AddModificationDateToFileInternal extends AddInternalLastModified {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToFileInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToFileInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addInternalLastModified;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_modificationDate_to_file.internal", description = "Add internal modificationDate to File #1810",
+        version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210812, deprecatedSince = "v3.0.0")
+public class AddModificationDateToFileInternal extends AddInternalLastModified {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToIndividualInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToIndividualInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_modificationDate_to_individual.internal", description = "Add internal modificationDate to Individual #1810",
         version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210812, deprecatedSince = "v3.0.0")
+        date = 20210812, deprecatedSince = "3.0.0")
 public class AddModificationDateToIndividualInternal extends AddInternalLastModified {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToIndividualInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToIndividualInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addInternalLastModified;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_modificationDate_to_individual.internal", description = "Add internal modificationDate to Individual #1810",
+        version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210812, deprecatedSince = "v3.0.0")
+public class AddModificationDateToIndividualInternal extends AddInternalLastModified {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToInterpretationInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToInterpretationInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_modificationDate_to_interpretation.internal", description = "Add internal modificationDate to Interpretation #1810",
         version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210812, deprecatedSince = "v3.0.0")
+        date = 20210812, deprecatedSince = "3.0.0")
 public class AddModificationDateToInterpretationInternal extends AddInternalLastModified {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToInterpretationInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToInterpretationInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addInternalLastModified;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_modificationDate_to_interpretation.internal", description = "Add internal modificationDate to Interpretation #1810",
+        version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210812, deprecatedSince = "v3.0.0")
+public class AddModificationDateToInterpretationInternal extends AddInternalLastModified {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToJobInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToJobInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addInternalLastModified;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_modificationDate_to_job.internal", description = "Add internal modificationDate to Job #1810", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210812, deprecatedSince = "v3.0.0")
+public class AddModificationDateToJobInternal extends AddInternalLastModified {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToJobInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToJobInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_modificationDate_to_job.internal", description = "Add internal modificationDate to Job #1810", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210812, deprecatedSince = "v3.0.0")
+        date = 20210812, deprecatedSince = "3.0.0")
 public class AddModificationDateToJobInternal extends AddInternalLastModified {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToProjectInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToProjectInternal.java
@@ -1,0 +1,14 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addInternalLastModified;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_modificationDate_to_project.internal", description = "Add internal modificationDate to Project #1810", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210812, deprecatedSince = "v3.0.0")
+public class AddModificationDateToProjectInternal extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToProjectInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToProjectInternal.java
@@ -5,7 +5,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
 
 @Migration(id = "add_modificationDate_to_project.internal", description = "Add internal modificationDate to Project #1810", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210812, deprecatedSince = "v3.0.0")
+        date = 20210812, deprecatedSince = "3.0.0")
 public class AddModificationDateToProjectInternal extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToSampleInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToSampleInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_modificationDate_to_sample.internal", description = "Add internal modificationDate to Sample #1810", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210812, deprecatedSince = "v3.0.0")
+        date = 20210812, deprecatedSince = "3.0.0")
 public class AddModificationDateToSampleInternal extends AddInternalLastModified {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToSampleInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToSampleInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addInternalLastModified;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_modificationDate_to_sample.internal", description = "Add internal modificationDate to Sample #1810", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210812, deprecatedSince = "v3.0.0")
+public class AddModificationDateToSampleInternal extends AddInternalLastModified {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToStudyInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToStudyInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addInternalLastModified;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_modificationDate_to_study.internal", description = "Add internal modificationDate to Study #1810", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210812, deprecatedSince = "v3.0.0")
+public class AddModificationDateToStudyInternal extends AddInternalLastModified {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToStudyInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInternalLastModified/AddModificationDateToStudyInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_modificationDate_to_study.internal", description = "Add internal modificationDate to Study #1810", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210812, deprecatedSince = "v3.0.0")
+        date = 20210812, deprecatedSince = "3.0.0")
 public class AddModificationDateToStudyInternal extends AddInternalLastModified {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInterpretationStats.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInterpretationStats.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_interpretation_stats",
+        description = "Add interpretation stats #1819", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        patch = 2,
+        date = 20210908, deprecatedSince = "v3.0.0")
+public class addInterpretationStats extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInterpretationStats.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addInterpretationStats.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         patch = 2,
-        date = 20210908, deprecatedSince = "v3.0.0")
+        date = 20210908, deprecatedSince = "3.0.0")
 public class addInterpretationStats extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDate.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDate.java
@@ -1,0 +1,10 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addRegistrationDate;
+
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+public abstract class AddRegistrationDate extends MigrationTool {
+
+    protected void addRegistrationDate(String collection) {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToClinicalInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToClinicalInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addRegistrationDate;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_registrationDate_to_clinical.internal", description = "Add registrationDate to Clinical #1804", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210720, deprecatedSince = "v3.0.0")
+public class AddRegistrationDateToClinicalInternal extends AddRegistrationDate {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToClinicalInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToClinicalInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_registrationDate_to_clinical.internal", description = "Add registrationDate to Clinical #1804", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210720, deprecatedSince = "v3.0.0")
+        date = 20210720, deprecatedSince = "3.0.0")
 public class AddRegistrationDateToClinicalInternal extends AddRegistrationDate {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToCohortInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToCohortInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addRegistrationDate;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_registrationDate_to_cohort.internal", description = "Add registrationDate to Cohort #1804", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210720, deprecatedSince = "v3.0.0")
+public class AddRegistrationDateToCohortInternal extends AddRegistrationDate {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToCohortInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToCohortInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_registrationDate_to_cohort.internal", description = "Add registrationDate to Cohort #1804", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210720, deprecatedSince = "v3.0.0")
+        date = 20210720, deprecatedSince = "3.0.0")
 public class AddRegistrationDateToCohortInternal extends AddRegistrationDate {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToFamilyInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToFamilyInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_registrationDate_to_family.internal", description = "Add registrationDate to Family #1804", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210720, deprecatedSince = "v3.0.0")
+        date = 20210720, deprecatedSince = "3.0.0")
 public class AddRegistrationDateToFamilyInternal extends AddRegistrationDate {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToFamilyInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToFamilyInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addRegistrationDate;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_registrationDate_to_family.internal", description = "Add registrationDate to Family #1804", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210720, deprecatedSince = "v3.0.0")
+public class AddRegistrationDateToFamilyInternal extends AddRegistrationDate {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToFileInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToFileInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addRegistrationDate;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_registrationDate_to_file.internal", description = "Add registrationDate to File #1804", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210720, deprecatedSince = "v3.0.0")
+public class AddRegistrationDateToFileInternal extends AddRegistrationDate {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToFileInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToFileInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_registrationDate_to_file.internal", description = "Add registrationDate to File #1804", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210720, deprecatedSince = "v3.0.0")
+        date = 20210720, deprecatedSince = "3.0.0")
 public class AddRegistrationDateToFileInternal extends AddRegistrationDate {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToIndividualInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToIndividualInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addRegistrationDate;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_registrationDate_to_individual.internal", description = "Add registrationDate to Individual #1804", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210720, deprecatedSince = "v3.0.0")
+public class AddRegistrationDateToIndividualInternal extends AddRegistrationDate {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToIndividualInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToIndividualInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_registrationDate_to_individual.internal", description = "Add registrationDate to Individual #1804", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210720, deprecatedSince = "v3.0.0")
+        date = 20210720, deprecatedSince = "3.0.0")
 public class AddRegistrationDateToIndividualInternal extends AddRegistrationDate {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToInterpretationInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToInterpretationInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_registrationDate_to_interpretation.internal", description = "Add registrationDate to Interpretation #1804",
         version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210720, deprecatedSince = "v3.0.0")
+        date = 20210720, deprecatedSince = "3.0.0")
 public class AddRegistrationDateToInterpretationInternal extends AddRegistrationDate {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToInterpretationInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToInterpretationInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addRegistrationDate;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_registrationDate_to_interpretation.internal", description = "Add registrationDate to Interpretation #1804",
+        version = "2.2.0", language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210720, deprecatedSince = "v3.0.0")
+public class AddRegistrationDateToInterpretationInternal extends AddRegistrationDate {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToJobInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToJobInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addRegistrationDate;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_registrationDate_to_job.internal", description = "Add registrationDate to Job #1804", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210720, deprecatedSince = "v3.0.0")
+public class AddRegistrationDateToJobInternal extends AddRegistrationDate {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToJobInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToJobInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_registrationDate_to_job.internal", description = "Add registrationDate to Job #1804", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210720, deprecatedSince = "v3.0.0")
+        date = 20210720, deprecatedSince = "3.0.0")
 public class AddRegistrationDateToJobInternal extends AddRegistrationDate {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToProjectInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToProjectInternal.java
@@ -1,0 +1,14 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addRegistrationDate;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_registrationDate_to_project.internal", description = "Add registrationDate to Project #1804", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210720, deprecatedSince = "v3.0.0")
+public class AddRegistrationDateToProjectInternal extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToProjectInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToProjectInternal.java
@@ -5,7 +5,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
 
 @Migration(id = "add_registrationDate_to_project.internal", description = "Add registrationDate to Project #1804", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210720, deprecatedSince = "v3.0.0")
+        date = 20210720, deprecatedSince = "3.0.0")
 public class AddRegistrationDateToProjectInternal extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToSampleInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToSampleInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_registrationDate_to_sample.internal", description = "Add registrationDate to Sample #1804", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210720, deprecatedSince = "v3.0.0")
+        date = 20210720, deprecatedSince = "3.0.0")
 public class AddRegistrationDateToSampleInternal extends AddRegistrationDate {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToSampleInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToSampleInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addRegistrationDate;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_registrationDate_to_sample.internal", description = "Add registrationDate to Sample #1804", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210720, deprecatedSince = "v3.0.0")
+public class AddRegistrationDateToSampleInternal extends AddRegistrationDate {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToStudyInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToStudyInternal.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id = "add_registrationDate_to_study.internal", description = "Add registrationDate to Study #1804", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
-        date = 20210720, deprecatedSince = "v3.0.0")
+        date = 20210720, deprecatedSince = "3.0.0")
 public class AddRegistrationDateToStudyInternal extends AddRegistrationDate {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToStudyInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRegistrationDate/AddRegistrationDateToStudyInternal.java
@@ -1,0 +1,13 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.addRegistrationDate;
+
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_registrationDate_to_study.internal", description = "Add registrationDate to Study #1804", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, domain = Migration.MigrationDomain.CATALOG,
+        date = 20210720, deprecatedSince = "v3.0.0")
+public class AddRegistrationDateToStudyInternal extends AddRegistrationDate {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRgaIndexToStudyInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRgaIndexToStudyInternal.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         patch = 1,
-        date = 20210719, deprecatedSince = "v3.0.0")
+        date = 20210719, deprecatedSince = "3.0.0")
 public class addRgaIndexToStudyInternal extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRgaIndexToStudyInternal.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/addRgaIndexToStudyInternal.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_rga_index_summary_to_study_internal",
+        description = "Add RGA Index information to Study Internal #", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        patch = 1,
+        date = 20210719, deprecatedSince = "v3.0.0")
+public class addRgaIndexToStudyInternal extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1795/AddFamilyIdsInIndividual.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1795/AddFamilyIdsInIndividual.java
@@ -5,7 +5,7 @@ import org.opencb.opencga.catalog.migration.MigrationException;
 import org.opencb.opencga.catalog.migration.MigrationTool;
 
 @Migration(id = "add_familyIds_in_individual", description = "Add new list of familyIds in Individual #1795", version = "2.2.0",
-        language = Migration.MigrationLanguage.JAVA, date = 20210630, deprecatedSince = "v3.0.0")
+        language = Migration.MigrationLanguage.JAVA, date = 20210630, deprecatedSince = "3.0.0")
 public class AddFamilyIdsInIndividual extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1795/AddFamilyIdsInIndividual.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1795/AddFamilyIdsInIndividual.java
@@ -1,0 +1,15 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1795;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationException;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_familyIds_in_individual", description = "Add new list of familyIds in Individual #1795", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, date = 20210630, deprecatedSince = "v3.0.0")
+public class AddFamilyIdsInIndividual extends MigrationTool {
+
+    @Override
+    protected void run() throws MigrationException {
+    }
+}
+

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1796/AddCohortIdsInSample.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1796/AddCohortIdsInSample.java
@@ -1,0 +1,15 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1796;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationException;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_cohortIds_in_sample", description = "Add new list of cohortIds in Sample #1796", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA, date = 20210706, deprecatedSince = "v3.0.0")
+public class AddCohortIdsInSample extends MigrationTool {
+
+    @Override
+    protected void run() throws MigrationException {
+    }
+}
+

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1796/AddCohortIdsInSample.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1796/AddCohortIdsInSample.java
@@ -5,7 +5,7 @@ import org.opencb.opencga.catalog.migration.MigrationException;
 import org.opencb.opencga.catalog.migration.MigrationTool;
 
 @Migration(id = "add_cohortIds_in_sample", description = "Add new list of cohortIds in Sample #1796", version = "2.2.0",
-        language = Migration.MigrationLanguage.JAVA, date = 20210706, deprecatedSince = "v3.0.0")
+        language = Migration.MigrationLanguage.JAVA, date = 20210706, deprecatedSince = "3.0.0")
 public class AddCohortIdsInSample extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteClinicalStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteClinicalStatusDataModel.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20211126,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class CompleteClinicalStatusDataModel extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteClinicalStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteClinicalStatusDataModel.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1849;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_clinical_status_models",
+        description = "Complete Clinical Status data models #1849", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211126,
+        deprecatedSince = "v3.0.0")
+public class CompleteClinicalStatusDataModel extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteCohortStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteCohortStatusDataModel.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1849;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_cohort_status_models",
+        description = "Complete Cohort Status data models #1849", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211126, deprecatedSince = "v3.0.0")
+public class CompleteCohortStatusDataModel extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteCohortStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteCohortStatusDataModel.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Complete Cohort Status data models #1849", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211126, deprecatedSince = "v3.0.0")
+        date = 20211126, deprecatedSince = "3.0.0")
 public class CompleteCohortStatusDataModel extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteFamilyStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteFamilyStatusDataModel.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Complete Family Status data models #1849", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211126, deprecatedSince = "v3.0.0")
+        date = 20211126, deprecatedSince = "3.0.0")
 public class CompleteFamilyStatusDataModel extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteFamilyStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteFamilyStatusDataModel.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1849;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_family_status_models",
+        description = "Complete Family Status data models #1849", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211126, deprecatedSince = "v3.0.0")
+public class CompleteFamilyStatusDataModel extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteFileStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteFileStatusDataModel.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1849;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_file_status_models",
+        description = "Complete File Status data models #1849", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211126, deprecatedSince = "v3.0.0")
+public class CompleteFileStatusDataModel extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteFileStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteFileStatusDataModel.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Complete File Status data models #1849", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211126, deprecatedSince = "v3.0.0")
+        date = 20211126, deprecatedSince = "3.0.0")
 public class CompleteFileStatusDataModel extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteIndividualStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteIndividualStatusDataModel.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Complete Individual Status data models #1849", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211126, deprecatedSince = "v3.0.0")
+        date = 20211126, deprecatedSince = "3.0.0")
 public class CompleteIndividualStatusDataModel extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteIndividualStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteIndividualStatusDataModel.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1849;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_individual_status_models",
+        description = "Complete Individual Status data models #1849", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211126, deprecatedSince = "v3.0.0")
+public class CompleteIndividualStatusDataModel extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteInterpretationStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteInterpretationStatusDataModel.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1849;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_interpretation_status_models",
+        description = "Complete Interpretation Status data models #1849", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211126, deprecatedSince = "v3.0.0")
+public class CompleteInterpretationStatusDataModel extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteInterpretationStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteInterpretationStatusDataModel.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Complete Interpretation Status data models #1849", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211126, deprecatedSince = "v3.0.0")
+        date = 20211126, deprecatedSince = "3.0.0")
 public class CompleteInterpretationStatusDataModel extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteJobStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteJobStatusDataModel.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Complete Job Status data models #1849", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211126, deprecatedSince = "v3.0.0")
+        date = 20211126, deprecatedSince = "3.0.0")
 public class CompleteJobStatusDataModel extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteJobStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteJobStatusDataModel.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1849;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_job_status_models",
+        description = "Complete Job Status data models #1849", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211126, deprecatedSince = "v3.0.0")
+public class CompleteJobStatusDataModel extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompletePanelStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompletePanelStatusDataModel.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1849;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_panel_status_models",
+        description = "Complete Panel Status data models #1849", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211126, deprecatedSince = "v3.0.0")
+public class CompletePanelStatusDataModel extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompletePanelStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompletePanelStatusDataModel.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Complete Panel Status data models #1849", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211126, deprecatedSince = "v3.0.0")
+        date = 20211126, deprecatedSince = "3.0.0")
 public class CompletePanelStatusDataModel extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteProjectStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteProjectStatusDataModel.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Complete Project Status data models #1849", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211126, deprecatedSince = "v3.0.0")
+        date = 20211126, deprecatedSince = "3.0.0")
 public class CompleteProjectStatusDataModel extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteProjectStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteProjectStatusDataModel.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1849;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_project_status_models",
+        description = "Complete Project Status data models #1849", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211126, deprecatedSince = "v3.0.0")
+public class CompleteProjectStatusDataModel extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteSampleStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteSampleStatusDataModel.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Complete Sample Status data models #1849", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211126, deprecatedSince = "v3.0.0")
+        date = 20211126, deprecatedSince = "3.0.0")
 public class CompleteSampleStatusDataModel extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteSampleStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteSampleStatusDataModel.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1849;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_sample_status_models",
+        description = "Complete Sample Status data models #1849", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211126, deprecatedSince = "v3.0.0")
+public class CompleteSampleStatusDataModel extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteStudyStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteStudyStatusDataModel.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Complete Study Status data models #1849", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211126, deprecatedSince = "v3.0.0")
+        date = 20211126, deprecatedSince = "3.0.0")
 public class CompleteStudyStatusDataModel extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteStudyStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteStudyStatusDataModel.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1849;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_study_status_models",
+        description = "Complete Study Status data models #1849", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211126, deprecatedSince = "v3.0.0")
+public class CompleteStudyStatusDataModel extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteUserStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteUserStatusDataModel.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issue_1849;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "complete_user_status_models",
+        description = "Complete User Status data models #1849", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211126, deprecatedSince = "v3.0.0")
+public class CompleteUserStatusDataModel extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteUserStatusDataModel.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issue_1849/CompleteUserStatusDataModel.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Complete User Status data models #1849", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211126, deprecatedSince = "v3.0.0")
+        date = 20211126, deprecatedSince = "3.0.0")
 public class CompleteUserStatusDataModel extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issues_1853_1855/IndividualOntologyTermMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issues_1853_1855/IndividualOntologyTermMigration.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Change sex and ethnicity types for OntologyTermAnnotation #1855", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211203, deprecatedSince = "v3.0.0")
+        date = 20211203, deprecatedSince = "3.0.0")
 public class IndividualOntologyTermMigration extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issues_1853_1855/IndividualOntologyTermMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issues_1853_1855/IndividualOntologyTermMigration.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issues_1853_1855;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "individual_ontology_term_migration_#1853",
+        description = "Change sex and ethnicity types for OntologyTermAnnotation #1855", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211203, deprecatedSince = "v3.0.0")
+public class IndividualOntologyTermMigration extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issues_1853_1855/NewStudyDataModelFields.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issues_1853_1855/NewStudyDataModelFields.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issues_1853_1855;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "new_study_data_model_fields_#1853",
+        description = "New Study 'sources', 'type' and 'additionalInfo' fields #1853", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211202, deprecatedSince = "v3.0.0")
+public class NewStudyDataModelFields extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issues_1853_1855/NewStudyDataModelFields.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issues_1853_1855/NewStudyDataModelFields.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "New Study 'sources', 'type' and 'additionalInfo' fields #1853", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211202, deprecatedSince = "v3.0.0")
+        date = 20211202, deprecatedSince = "3.0.0")
 public class NewStudyDataModelFields extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issues_1853_1855/SampleProcessingAndCollectionChanges.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issues_1853_1855/SampleProcessingAndCollectionChanges.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog.issues_1853_1855;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "sample_source_treatments_#1854",
+        description = "Sample source, treatments, processing and collection changes #1854", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20211201, patch = 2, deprecatedSince = "v3.0.0")
+public class SampleProcessingAndCollectionChanges extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issues_1853_1855/SampleProcessingAndCollectionChanges.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/issues_1853_1855/SampleProcessingAndCollectionChanges.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Sample source, treatments, processing and collection changes #1854", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20211201, patch = 2, deprecatedSince = "v3.0.0")
+        date = 20211201, patch = 2, deprecatedSince = "3.0.0")
 public class SampleProcessingAndCollectionChanges extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/renameVariableSetFieldFromVariable.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/renameVariableSetFieldFromVariable.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Rename Variable variableSet field to variables #1823", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20210920, deprecatedSince = "v3.0.0")
+        date = 20210920, deprecatedSince = "3.0.0")
 public class renameVariableSetFieldFromVariable extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/renameVariableSetFieldFromVariable.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/catalog/renameVariableSetFieldFromVariable.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.catalog;
+
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "rename_variableset_field",
+        description = "Rename Variable variableSet field to variables #1823", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20210920, deprecatedSince = "v3.0.0")
+public class renameVariableSetFieldFromVariable extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/storage/SynchronizeCatalogStorage.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/storage/SynchronizeCatalogStorage.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.Migration;
         description = "Synchronize catalog storage #1850 #1851", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.STORAGE,
-        date = 20220118, deprecatedSince = "v3.0.0")
+        date = 20220118, deprecatedSince = "3.0.0")
 public class SynchronizeCatalogStorage extends StorageMigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/storage/SynchronizeCatalogStorage.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/storage/SynchronizeCatalogStorage.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.storage;
+
+import org.opencb.opencga.app.migrations.StorageMigrationTool;
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "synchronize_catalog_storage_1850_1851",
+        description = "Synchronize catalog storage #1850 #1851", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.STORAGE,
+        date = 20220118, deprecatedSince = "v3.0.0")
+public class SynchronizeCatalogStorage extends StorageMigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/storage/UpdateSampleIndexStatus.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/storage/UpdateSampleIndexStatus.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.Migration;
         description = " Improve sample-index multi-schema management. #1901", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.STORAGE,
-        date = 20220302, deprecatedSince = "v3.0.0")
+        date = 20220302, deprecatedSince = "3.0.0")
 public class UpdateSampleIndexStatus extends StorageMigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/storage/UpdateSampleIndexStatus.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_0/storage/UpdateSampleIndexStatus.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_0.storage;
+
+import org.opencb.opencga.app.migrations.StorageMigrationTool;
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "update_sample_index_status_1901",
+        description = " Improve sample-index multi-schema management. #1901", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.STORAGE,
+        date = 20220302, deprecatedSince = "v3.0.0")
+public class UpdateSampleIndexStatus extends StorageMigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/catalog/AddMissingBiotypes.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/catalog/AddMissingBiotypes.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_1.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_missing_biotypes",
+        description = "Add missing biotypes, #TASK-625", version = "2.2.1",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220412, deprecatedSince = "v3.0.0")
+public class AddMissingBiotypes extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/catalog/AddMissingBiotypes.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/catalog/AddMissingBiotypes.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Add missing biotypes, #TASK-625", version = "2.2.1",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20220412, deprecatedSince = "v3.0.0")
+        date = 20220412, deprecatedSince = "3.0.0")
 public class AddMissingBiotypes extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/catalog/AddPanelGeneNameIndex.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/catalog/AddPanelGeneNameIndex.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_1.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_panel_gene_name_index",
+        description = "Add Panel gene.name index #TASK-602", version = "2.2.1",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220406, deprecatedSince = "v3.0.0")
+public class AddPanelGeneNameIndex extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/catalog/AddPanelGeneNameIndex.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/catalog/AddPanelGeneNameIndex.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Add Panel gene.name index #TASK-602", version = "2.2.1",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20220406, deprecatedSince = "v3.0.0")
+        date = 20220406, deprecatedSince = "3.0.0")
 public class AddPanelGeneNameIndex extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/catalog/InitSharedProjectField.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/catalog/InitSharedProjectField.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_1.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "init_shared_project",
+        description = "Initialise sharedProjects #TASK-702", version = "2.2.1",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220502, deprecatedSince = "v3.0.0")
+public class InitSharedProjectField extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/catalog/InitSharedProjectField.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/catalog/InitSharedProjectField.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         description = "Initialise sharedProjects #TASK-702", version = "2.2.1",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
-        date = 20220502, deprecatedSince = "v3.0.0")
+        date = 20220502, deprecatedSince = "3.0.0")
 public class InitSharedProjectField extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/storage/SampleIndexConfigurationAddMissingStatus.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/storage/SampleIndexConfigurationAddMissingStatus.java
@@ -1,0 +1,15 @@
+package org.opencb.opencga.app.migrations.v2.v2_2_1.storage;
+
+import org.opencb.opencga.app.migrations.StorageMigrationTool;
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "sample_index_configuration_add_missing_status",
+        description = "Sample index configuration add missing status #TASK-512", version = "2.2.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.STORAGE,
+        date = 20220328, deprecatedSince = "v3.0.0")
+public class SampleIndexConfigurationAddMissingStatus extends StorageMigrationTool {
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/storage/SampleIndexConfigurationAddMissingStatus.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_2_1/storage/SampleIndexConfigurationAddMissingStatus.java
@@ -7,7 +7,7 @@ import org.opencb.opencga.catalog.migration.Migration;
         description = "Sample index configuration add missing status #TASK-512", version = "2.2.0",
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.STORAGE,
-        date = 20220328, deprecatedSince = "v3.0.0")
+        date = 20220328, deprecatedSince = "3.0.0")
 public class SampleIndexConfigurationAddMissingStatus extends StorageMigrationTool {
     @Override
     protected void run() throws Exception {

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/AddLockedToInterpretation.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/AddLockedToInterpretation.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220401,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class AddLockedToInterpretation extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/AddLockedToInterpretation.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/AddLockedToInterpretation.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_3_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_locked_to_interpretation_TASK-552",
+        description = "Add new 'locked' field to Interpretation #TASK-552", version = "2.3.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220401,
+        deprecatedSince = "v3.0.0")
+public class AddLockedToInterpretation extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/AddPanelInternalField.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/AddPanelInternalField.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_3_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_panel_internal_field-TASK_734",
+        description = "Add 'internal' to Panel data model #TASK-734", version = "2.3.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220509,
+        deprecatedSince = "v3.0.0")
+public class AddPanelInternalField extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/AddPanelInternalField.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/AddPanelInternalField.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220509,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class AddPanelInternalField extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/AutoIncrementVersion.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/AutoIncrementVersion.java
@@ -1,0 +1,19 @@
+package org.opencb.opencga.app.migrations.v2.v2_3_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "autoincrement_version_TASK-323",
+        description = "Reorganise data in new collections (autoincrement version) #TASK-323", version = "2.3.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        offline = true,
+        date = 20220512,
+        deprecatedSince = "v3.0.0")
+public class AutoIncrementVersion extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/AutoIncrementVersion.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/AutoIncrementVersion.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         offline = true,
         date = 20220512,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class AutoIncrementVersion extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/InitSampleIndexConfiguration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/InitSampleIndexConfiguration.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_3_0.catalog;
+
+import org.opencb.opencga.app.migrations.StorageMigrationTool;
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "init_sampleIndexConfiguration-TASK550",
+        description = "Initialise SampleIndexConfiguration in Study internal #TASK-550", version = "2.3.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220502,
+        deprecatedSince = "v3.0.0")
+public class InitSampleIndexConfiguration extends StorageMigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/InitSampleIndexConfiguration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/InitSampleIndexConfiguration.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.Migration;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220502,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class InitSampleIndexConfiguration extends StorageMigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/MoveCellbaseFromProjectInternalToProject.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/MoveCellbaseFromProjectInternalToProject.java
@@ -1,0 +1,19 @@
+package org.opencb.opencga.app.migrations.v2.v2_3_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "move_cellbase_from_project_internal_to_project_TASK-354",
+        description = "Move cellbase from project.internal to project #TASK-354", version = "2.3.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220422,
+        deprecatedSince = "v3.0.0")
+
+public class MoveCellbaseFromProjectInternalToProject extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/MoveCellbaseFromProjectInternalToProject.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/MoveCellbaseFromProjectInternalToProject.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220422,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 
 public class MoveCellbaseFromProjectInternalToProject extends MigrationTool {
 

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/RenameDeletedCollections.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/RenameDeletedCollections.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_3_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "rename_deleted_collections_TASK-359",
+        description = "Rename deleted collections #TASK-359", version = "2.3.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220502,
+        deprecatedSince = "v3.0.0")
+public class RenameDeletedCollections extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/RenameDeletedCollections.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/RenameDeletedCollections.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220502,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class RenameDeletedCollections extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/RenameDeprecatedVariantStorageToolId.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/RenameDeprecatedVariantStorageToolId.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_3_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "rename_variant_storage_tool_ids_TASK-705",
+        description = "Rename variant storage tool ids #TASK-705", version = "2.3.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220506,
+        deprecatedSince = "v3.0.0")
+public class RenameDeprecatedVariantStorageToolId extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/RenameDeprecatedVariantStorageToolId.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/RenameDeprecatedVariantStorageToolId.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220506,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class RenameDeprecatedVariantStorageToolId extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/UpdateJWTSecretKey.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/UpdateJWTSecretKey.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220513,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class UpdateJWTSecretKey extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/UpdateJWTSecretKey.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/catalog/UpdateJWTSecretKey.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_3_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "update_jwt_secret_key_TASK-807",
+        description = "Update JWT secret key #TASK-807", version = "2.3.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220513,
+        deprecatedSince = "v3.0.0")
+public class UpdateJWTSecretKey extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/storage/AddMissingColumnsToPhoenix.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/storage/AddMissingColumnsToPhoenix.java
@@ -1,0 +1,14 @@
+package org.opencb.opencga.app.migrations.v2.v2_3_0.storage;
+
+import org.opencb.opencga.app.migrations.StorageMigrationTool;
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id="add_missing_columns_to_phoenix_TASK-789", description = "Add missing 1000G columns to phoenix #TASK-789",
+        version = "2.3.0", domain = Migration.MigrationDomain.STORAGE, date = 20220614, deprecatedSince = "v3.0.0"
+)
+public class AddMissingColumnsToPhoenix extends StorageMigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/storage/AddMissingColumnsToPhoenix.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_0/storage/AddMissingColumnsToPhoenix.java
@@ -4,7 +4,7 @@ import org.opencb.opencga.app.migrations.StorageMigrationTool;
 import org.opencb.opencga.catalog.migration.Migration;
 
 @Migration(id="add_missing_columns_to_phoenix_TASK-789", description = "Add missing 1000G columns to phoenix #TASK-789",
-        version = "2.3.0", domain = Migration.MigrationDomain.STORAGE, date = 20220614, deprecatedSince = "v3.0.0"
+        version = "2.3.0", domain = Migration.MigrationDomain.STORAGE, date = 20220614, deprecatedSince = "3.0.0"
 )
 public class AddMissingColumnsToPhoenix extends StorageMigrationTool {
 

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_1/catalog/MoveCellbaseFromProjectInternalToProjectBugFix.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_1/catalog/MoveCellbaseFromProjectInternalToProjectBugFix.java
@@ -1,0 +1,19 @@
+package org.opencb.opencga.app.migrations.v2.v2_3_1.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "bugfix_move_cellbase_from_project_internal_to_project_TASK-1100",
+        description = "Bugfix: Move cellbase from project.internal to project #TASK-1100", version = "2.3.1",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220620,
+        deprecatedSince = "v3.0.0")
+
+public class MoveCellbaseFromProjectInternalToProjectBugFix extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_1/catalog/MoveCellbaseFromProjectInternalToProjectBugFix.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_3_1/catalog/MoveCellbaseFromProjectInternalToProjectBugFix.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220620,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 
 public class MoveCellbaseFromProjectInternalToProjectBugFix extends MigrationTool {
 

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_0/catalog/AddClinicalStatusType_607.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_0/catalog/AddClinicalStatusType_607.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220610,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class AddClinicalStatusType_607 extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_0/catalog/AddClinicalStatusType_607.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_0/catalog/AddClinicalStatusType_607.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_clinical_status_type_TASK-607",
+        description = "Automatically close cases depending on the new clinical status type #TASK-607", version = "2.4.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220610,
+        deprecatedSince = "v3.0.0")
+public class AddClinicalStatusType_607 extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_0/catalog/AddPrivateDueDate_803.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_0/catalog/AddPrivateDueDate_803.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_private_dueDate_TASK-803",
+        description = "Add private _dueDate to ClinicalAnalysis #TASK-803", version = "2.4.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220530,
+        deprecatedSince = "v3.0.0")
+public class AddPrivateDueDate_803 extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_0/catalog/AddPrivateDueDate_803.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_0/catalog/AddPrivateDueDate_803.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220530,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class AddPrivateDueDate_803 extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_0/catalog/IndexPanelSource.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_0/catalog/IndexPanelSource.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "index_panel_source_TASK-473",
+        description = "Index panel source #TASK-473", version = "2.4.0",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220530,
+        deprecatedSince = "v3.0.0")
+public class IndexPanelSource extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_0/catalog/IndexPanelSource.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_0/catalog/IndexPanelSource.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220530,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class IndexPanelSource extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_10/catalog/AddMissingEndDateOnFinishedJobs.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_10/catalog/AddMissingEndDateOnFinishedJobs.java
@@ -1,0 +1,20 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_10.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_missing_endDate_on_finished_jobs" ,
+        description = "Add missing end date on finished jobs",
+        version = "2.4.10",
+        domain = Migration.MigrationDomain.CATALOG,
+        language = Migration.MigrationLanguage.JAVA,
+        date = 20221026,
+        deprecatedSince = "v3.0.0"
+)
+public class AddMissingEndDateOnFinishedJobs extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_10/catalog/AddMissingEndDateOnFinishedJobs.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_10/catalog/AddMissingEndDateOnFinishedJobs.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         language = Migration.MigrationLanguage.JAVA,
         date = 20221026,
-        deprecatedSince = "v3.0.0"
+        deprecatedSince = "3.0.0"
 )
 public class AddMissingEndDateOnFinishedJobs extends MigrationTool {
 

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_11/SynchronizeCatalogStorageStatuses.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_11/SynchronizeCatalogStorageStatuses.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.Migration;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.STORAGE,
         date = 20221117,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class SynchronizeCatalogStorageStatuses extends StorageMigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_11/SynchronizeCatalogStorageStatuses.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_11/SynchronizeCatalogStorageStatuses.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_11;
+
+import org.opencb.opencga.app.migrations.StorageMigrationTool;
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "synchronize_catalog_storage_statuses",
+        description = "Synchronize catalog internal statuses from storage, #TASK-1304", version = "2.4.11",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.STORAGE,
+        date = 20221117,
+        deprecatedSince = "v3.0.0")
+public class SynchronizeCatalogStorageStatuses extends StorageMigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_11/catalog/SignatureFittingsMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_11/catalog/SignatureFittingsMigration.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_11.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "signature_fittings" ,
+        description = "Replace fitting for fittings in Signature",
+        version = "2.4.11",
+        domain = Migration.MigrationDomain.CATALOG,
+        language = Migration.MigrationLanguage.JAVA,
+        date = 20221109,
+        deprecatedSince = "v3.0.0"
+)
+public class SignatureFittingsMigration extends MigrationTool {
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_11/catalog/SignatureFittingsMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_11/catalog/SignatureFittingsMigration.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         language = Migration.MigrationLanguage.JAVA,
         date = 20221109,
-        deprecatedSince = "v3.0.0"
+        deprecatedSince = "3.0.0"
 )
 public class SignatureFittingsMigration extends MigrationTool {
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_2/catalog/AddClinicalDiscussion.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_2/catalog/AddClinicalDiscussion.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_2.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "add_clinical_discussion_TASK-1472",
+        description = "Add ClinicalDiscussion #TASK-1472", version = "2.4.2",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220727,
+        deprecatedSince = "v3.0.0")
+public class AddClinicalDiscussion extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_2/catalog/AddClinicalDiscussion.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_2/catalog/AddClinicalDiscussion.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220727,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class AddClinicalDiscussion extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_2/catalog/RecoverProbandSamplesInCases.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_2/catalog/RecoverProbandSamplesInCases.java
@@ -1,0 +1,19 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_2.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "recover_proband_samples_in_cases_TASK-1470",
+        description = "Recover lost samples in clinical collection #TASK-1470", version = "2.4.2",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220725,
+        patch = 2,
+        deprecatedSince = "v3.0.0")
+public class RecoverProbandSamplesInCases extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_2/catalog/RecoverProbandSamplesInCases.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_2/catalog/RecoverProbandSamplesInCases.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220725,
         patch = 2,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class RecoverProbandSamplesInCases extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_3/catalog/MigrateToClinicalAcmg.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_3/catalog/MigrateToClinicalAcmg.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_3.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "migrate_to_clinical_acmg_TASK-1194",
+        description = "Migrate to ClinicalAcmg #TASK-1194", version = "2.4.3",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220809,
+        deprecatedSince = "v3.0.0")
+public class MigrateToClinicalAcmg extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_3/catalog/MigrateToClinicalAcmg.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_3/catalog/MigrateToClinicalAcmg.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220809,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class MigrateToClinicalAcmg extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_3/catalog/ShortenIndexedFieldVariables.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_3/catalog/ShortenIndexedFieldVariables.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220809,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class ShortenIndexedFieldVariables extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_3/catalog/ShortenIndexedFieldVariables.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_3/catalog/ShortenIndexedFieldVariables.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_3.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "shorten_indexed_field_variables-1386",
+        description = "Shorten indexed field variables #TASK-1386", version = "2.4.3",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220809,
+        deprecatedSince = "v3.0.0")
+public class ShortenIndexedFieldVariables extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_4/catalog/AvoidCaseStatusIdNullMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_4/catalog/AvoidCaseStatusIdNullMigration.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220914,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class AvoidCaseStatusIdNullMigration extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_4/catalog/AvoidCaseStatusIdNullMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_4/catalog/AvoidCaseStatusIdNullMigration.java
@@ -1,0 +1,18 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_4.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "avoidCaseStatusIdNull-1938",
+        description = "Avoid nullable status id in Clinical Analysis #TASK-1938", version = "2.4.4",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220914,
+        deprecatedSince = "v3.0.0")
+public class AvoidCaseStatusIdNullMigration extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_4/catalog/RemoveBiotypeAllowedKeysMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_4/catalog/RemoveBiotypeAllowedKeysMigration.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.CATALOG,
         date = 20220905,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class RemoveBiotypeAllowedKeysMigration extends MigrationTool {
 
     @Override

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_4/catalog/RemoveBiotypeAllowedKeysMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_4/catalog/RemoveBiotypeAllowedKeysMigration.java
@@ -1,0 +1,17 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_4.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "remove_biotype_allowed_keys_TASK-1849",
+        description = "Remove biotype and consequence type allowed keys from variable sets #TASK-1849", version = "2.4.4",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.CATALOG,
+        date = 20220905,
+        deprecatedSince = "v3.0.0")
+public class RemoveBiotypeAllowedKeysMigration extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_4/storage/InvalidateVariantArchivesMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_4/storage/InvalidateVariantArchivesMigration.java
@@ -1,0 +1,16 @@
+package org.opencb.opencga.app.migrations.v2.v2_4_4.storage;
+
+import org.opencb.opencga.app.migrations.StorageMigrationTool;
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "invalidate_variant_archives_migration-633",
+        description = "Invalidate variant archives from variant storage hadoop #TASK-633", version = "2.4.4",
+        language = Migration.MigrationLanguage.JAVA,
+        domain = Migration.MigrationDomain.STORAGE,
+        date = 20220825,
+        deprecatedSince = "v3.0.0")
+public class InvalidateVariantArchivesMigration extends StorageMigrationTool {
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_4/storage/InvalidateVariantArchivesMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_4_4/storage/InvalidateVariantArchivesMigration.java
@@ -8,7 +8,7 @@ import org.opencb.opencga.catalog.migration.Migration;
         language = Migration.MigrationLanguage.JAVA,
         domain = Migration.MigrationDomain.STORAGE,
         date = 20220825,
-        deprecatedSince = "v3.0.0")
+        deprecatedSince = "3.0.0")
 public class InvalidateVariantArchivesMigration extends StorageMigrationTool {
     @Override
     protected void run() throws Exception {

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_6_0/storage/AddCellbaseDataRelease.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_6_0/storage/AddCellbaseDataRelease.java
@@ -1,0 +1,20 @@
+package org.opencb.opencga.app.migrations.v2.v2_6_0.storage;
+
+import org.opencb.opencga.app.migrations.StorageMigrationTool;
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "add_cellbase_data_release" ,
+        description = "Add default cellbase data release if missing",
+        version = "2.6.0",
+        domain = Migration.MigrationDomain.STORAGE,
+        language = Migration.MigrationLanguage.JAVA,
+        patch = 2,
+        date = 20230104,
+        deprecatedSince = "v3.0.0"
+)
+public class AddCellbaseDataRelease extends StorageMigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_6_0/storage/AddCellbaseDataRelease.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_6_0/storage/AddCellbaseDataRelease.java
@@ -10,7 +10,7 @@ import org.opencb.opencga.catalog.migration.Migration;
         language = Migration.MigrationLanguage.JAVA,
         patch = 2,
         date = 20230104,
-        deprecatedSince = "v3.0.0"
+        deprecatedSince = "3.0.0"
 )
 public class AddCellbaseDataRelease extends StorageMigrationTool {
 

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_7_0/catalog/CancerRoleAndModeOfInheritanceMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_7_0/catalog/CancerRoleAndModeOfInheritanceMigration.java
@@ -1,0 +1,20 @@
+package org.opencb.opencga.app.migrations.v2.v2_7_0.catalog;
+
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "panel_roles_and_modesOfInheritance" ,
+        description = "Change panel cancer.role and modeOfInheritance for cancer.roles[] and modesOfInheritance[]",
+        version = "2.7.0",
+        domain = Migration.MigrationDomain.CATALOG,
+        language = Migration.MigrationLanguage.JAVA,
+        date = 20230117,
+        deprecatedSince = "v3.0.0"
+)
+public class CancerRoleAndModeOfInheritanceMigration extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_7_0/catalog/CancerRoleAndModeOfInheritanceMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_7_0/catalog/CancerRoleAndModeOfInheritanceMigration.java
@@ -10,7 +10,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         language = Migration.MigrationLanguage.JAVA,
         date = 20230117,
-        deprecatedSince = "v3.0.0"
+        deprecatedSince = "3.0.0"
 )
 public class CancerRoleAndModeOfInheritanceMigration extends MigrationTool {
 

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_8_0/catalog/CalculatePedigreeGraphMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_8_0/catalog/CalculatePedigreeGraphMigration.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         language = Migration.MigrationLanguage.JAVA,
         date = 20230313,
-        deprecatedSince = "v3.0.0"
+        deprecatedSince = "3.0.0"
 )
 public class CalculatePedigreeGraphMigration extends MigrationTool {
 

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_8_0/catalog/CalculatePedigreeGraphMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_8_0/catalog/CalculatePedigreeGraphMigration.java
@@ -1,0 +1,19 @@
+package org.opencb.opencga.app.migrations.v2.v2_8_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "calculate_pedigree_graph" ,
+        description = "Calculate Pedigree Graph for all the families",
+        version = "2.8.0",
+        domain = Migration.MigrationDomain.CATALOG,
+        language = Migration.MigrationLanguage.JAVA,
+        date = 20230313,
+        deprecatedSince = "v3.0.0"
+)
+public class CalculatePedigreeGraphMigration extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_8_6/storage/MarkUnknownLargestVariantLength.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_8_6/storage/MarkUnknownLargestVariantLength.java
@@ -10,7 +10,7 @@ import org.opencb.opencga.catalog.migration.Migration;
         language = Migration.MigrationLanguage.JAVA,
         patch = 1,
         date = 20230927,
-        deprecatedSince = "v3.0.0"
+        deprecatedSince = "3.0.0"
 )
 public class MarkUnknownLargestVariantLength extends StorageMigrationTool {
 

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_8_6/storage/MarkUnknownLargestVariantLength.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_8_6/storage/MarkUnknownLargestVariantLength.java
@@ -1,0 +1,20 @@
+package org.opencb.opencga.app.migrations.v2.v2_8_6.storage;
+
+import org.opencb.opencga.app.migrations.StorageMigrationTool;
+import org.opencb.opencga.catalog.migration.Migration;
+
+@Migration(id = "mark_unknown_largest_variant_length" ,
+        description = "Mark as unknown largest variant length",
+        version = "2.8.6",
+        domain = Migration.MigrationDomain.STORAGE,
+        language = Migration.MigrationLanguage.JAVA,
+        patch = 1,
+        date = 20230927,
+        deprecatedSince = "v3.0.0"
+)
+public class MarkUnknownLargestVariantLength extends StorageMigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_9_0/catalog/RenameCellBaseToken2ApiKey.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_9_0/catalog/RenameCellBaseToken2ApiKey.java
@@ -1,0 +1,20 @@
+package org.opencb.opencga.app.migrations.v2.v2_9_0.catalog;
+
+import org.opencb.opencga.catalog.migration.Migration;
+import org.opencb.opencga.catalog.migration.MigrationTool;
+
+@Migration(id = "rename_cellbase_token_2_api_key" ,
+        description = "Rename CellBase Token to ApiKey",
+        version = "2.9.0",
+        domain = Migration.MigrationDomain.CATALOG,
+        language = Migration.MigrationLanguage.JAVA,
+        date = 20230829,
+        deprecatedSince = "v3.0.0"
+)
+public class RenameCellBaseToken2ApiKey extends MigrationTool {
+
+    @Override
+    protected void run() throws Exception {
+    }
+
+}

--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_9_0/catalog/RenameCellBaseToken2ApiKey.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v2/v2_9_0/catalog/RenameCellBaseToken2ApiKey.java
@@ -9,7 +9,7 @@ import org.opencb.opencga.catalog.migration.MigrationTool;
         domain = Migration.MigrationDomain.CATALOG,
         language = Migration.MigrationLanguage.JAVA,
         date = 20230829,
-        deprecatedSince = "v3.0.0"
+        deprecatedSince = "3.0.0"
 )
 public class RenameCellBaseToken2ApiKey extends MigrationTool {
 

--- a/opencga-catalog/src/main/java/org/opencb/opencga/catalog/migration/Migration.java
+++ b/opencga-catalog/src/main/java/org/opencb/opencga/catalog/migration/Migration.java
@@ -54,6 +54,11 @@ public @interface Migration {
      */
     boolean manual() default false;
 
+    /**
+     * @return the version when the migration was deprecated.
+     */
+    String deprecatedSince() default "";
+
     enum MigrationDomain {
         CATALOG,
         STORAGE

--- a/opencga-catalog/src/main/java/org/opencb/opencga/catalog/migration/MigrationException.java
+++ b/opencga-catalog/src/main/java/org/opencb/opencga/catalog/migration/MigrationException.java
@@ -20,4 +20,10 @@ public class MigrationException extends CatalogException {
         return new MigrationException("Migration '" + migration.id() + "' requires database to be offline. Please, ensure the database "
                 + "cannot be accessed and run try again with '--offline' flag.");
     }
+
+    public static MigrationException deprecatedMigration(Migration migration) {
+        return new MigrationException("Migration '" + migration.id() + "' can't be run since version '"
+                + migration.deprecatedSince() + "'. Please, run this migration from a previous OpenCGA version.");
+    }
+
 }

--- a/opencga-catalog/src/main/java/org/opencb/opencga/catalog/migration/MigrationManager.java
+++ b/opencga-catalog/src/main/java/org/opencb/opencga/catalog/migration/MigrationManager.java
@@ -622,6 +622,11 @@ public class MigrationManager {
                              String token) throws MigrationException {
         Migration annotation = getMigrationAnnotation(runnableMigration);
 
+        if (StringUtils.isNotEmpty(annotation.deprecatedSince())) {
+            throw new MigrationException("Migration '" + annotation.id() + "' can't be run since version '" + annotation.deprecatedSince()
+                    + "'. Please, run this migration from a previous OpenCGA version.");
+        }
+
         MigrationTool migrationTool;
         try {
             migrationTool = runnableMigration.newInstance();

--- a/opencga-catalog/src/main/java/org/opencb/opencga/catalog/migration/MigrationManager.java
+++ b/opencga-catalog/src/main/java/org/opencb/opencga/catalog/migration/MigrationManager.java
@@ -623,8 +623,7 @@ public class MigrationManager {
         Migration annotation = getMigrationAnnotation(runnableMigration);
 
         if (StringUtils.isNotEmpty(annotation.deprecatedSince())) {
-            throw new MigrationException("Migration '" + annotation.id() + "' can't be run since version '" + annotation.deprecatedSince()
-                    + "'. Please, run this migration from a previous OpenCGA version.");
+            throw MigrationException.deprecatedMigration(annotation);
         }
 
         MigrationTool migrationTool;

--- a/opencga-catalog/src/main/java/org/opencb/opencga/catalog/migration/MigrationTool.java
+++ b/opencga-catalog/src/main/java/org/opencb/opencga/catalog/migration/MigrationTool.java
@@ -81,8 +81,7 @@ public abstract class MigrationTool {
         try {
             Migration annotation = getAnnotation();
             if (StringUtils.isNotEmpty(annotation.deprecatedSince())) {
-                throw new MigrationException("Migration '" + annotation.id() + "' can't be run since version '"
-                        + annotation.deprecatedSince() + "'. Please, run this migration from a previous OpenCGA version.");
+                throw MigrationException.deprecatedMigration(annotation);
             }
             run();
         } catch (MigrationException e) {

--- a/opencga-catalog/src/main/java/org/opencb/opencga/catalog/migration/MigrationTool.java
+++ b/opencga-catalog/src/main/java/org/opencb/opencga/catalog/migration/MigrationTool.java
@@ -4,6 +4,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.WriteModel;
+import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.opencb.commons.ProgressLogger;
@@ -78,6 +79,11 @@ public abstract class MigrationTool {
 
     public final void execute() throws MigrationException {
         try {
+            Migration annotation = getAnnotation();
+            if (StringUtils.isNotEmpty(annotation.deprecatedSince())) {
+                throw new MigrationException("Migration '" + annotation.id() + "' can't be run since version '"
+                        + annotation.deprecatedSince() + "'. Please, run this migration from a previous OpenCGA version.");
+            }
             run();
         } catch (MigrationException e) {
             throw e;


### PR DESCRIPTION
- recover old v2.x migrations and marked them as deprecated
- check all previous migrations were successfully run before moving to v3.0.0
- keep track of previous migrations