### PR TITLE
TASK-7207 - Fix Organization migration issue

### DIFF
--- a/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v3/v3_0_0/OrganizationMigration.java
+++ b/opencga-app/src/main/java/org/opencb/opencga/app/migrations/v3/v3_0_0/OrganizationMigration.java
@@ -579,9 +579,15 @@ public class OrganizationMigration extends MigrationTool {
                         ))
                 );
 
+                // Ensure all jobs have attributes field
+                Bson jobQuery = Filters.eq("attributes", null);
+                Bson update = new Document("$set", new Document("attributes", new Document()));
+                jobCollection.updateMany(jobQuery, update);
+                jobDeletedCollection.updateMany(jobQuery, update);
+
                 // Change fqn in all jobs that were pointing to this study
-                Bson jobQuery = Filters.eq("studyUid", studyUid);
-                Bson update = new Document("$set", new Document()
+                jobQuery = Filters.eq("studyUid", studyUid);
+                update = new Document("$set", new Document()
                         .append("study.id", newFqn)
                         .append("attributes.OPENCGA.3_0_0", new Document()
                                 .append("date", date)


### PR DESCRIPTION
Main Organization migration could give an error if there's a job whose `attributes` field is null. 