### PR TITLE
TASK-6880 - CI/CD workflow to delete task docker images on merge fails

### DIFF
--- a/.github/workflows/pull-request-merged.yml
+++ b/.github/workflows/pull-request-merged.yml
@@ -7,18 +7,11 @@ on:
       - "release-*"
     types:
       - closed
-  workflow_dispatch:
 
 jobs:
-  build:
-    uses: opencb/java-common-libs/.github/workflows/build-java-app-workflow.yml@develop
+  call-delete-docker:
+    name: Call Reusable Delete Docker Workflow
+    uses: opencb/opencga/.github/workflows/reusable-delete-docker.yml@develop
     with:
-      maven_opts: -P hdp3.1,RClient -Dopencga.war.name=opencga -Dcheckstyle.skip
-
-  delete-docker:
-    uses: opencb/java-common-libs/.github/workflows/delete-docker-hub-workflow.yml@develop
-    needs: build
-    with:
-      cli: python3 ./build/cloud/docker/docker-build.py delete --images base --tag ${{ github.head_ref }}
+      task: ${{ github.head_ref }}
     secrets: inherit
-


### PR DESCRIPTION
[TASK-6880 - CI/CD workflow to delete task docker images on merge fails](https://app.clickup.com/t/36631768/TASK-6880)